### PR TITLE
fix: Don't run tests on master

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,6 +1,13 @@
 name: Run tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      # Master is locked down and will only accept pull requests. Since they already
+      # have been tested, don't test them again.
+      - 'master'
+
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
After adding running tests on push, I caused a regression as now every pull request would be
tested twice. One before closing and again after closing. This limits running tests to
non-master branches.

<!---
When opening the PR, your commit messages for a given branch will automatically be
added to the CHANGELOG. Please keep it clear. You can prepend the summary with ``chg``,
``fix`` or ``new`` to insert the message in the correct category.
Adding ``!minor`` or ``!cosmetics`` will cause the commit not to be noted in the
changelog.
--->

# Description

# Closes issue(s)

  Fixes: #<issue number>

# Changes included (select only one)
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist
- [ ] Code passes tox
