### PR TITLE
issur_melacha should include candle_lighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ htmlcov/
 .tox
 .cache
 .pytest_cache/
+.vscode/settings.json

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -188,7 +188,7 @@ class Zmanim(BaseClass):
         if (today.is_shabbat or today.is_yom_tov) and (self.time < self.havdalah):
             return True
         if (tomorrow.is_shabbat or tomorrow.is_yom_tov) and (
-            self.time > self.candle_lighting
+            self.time >= self.candle_lighting
         ):
             return True
 

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -82,7 +82,7 @@ class TestZmanim(object):
     # Times are assumed for NYC.
     CANDLES_TEST = [
         (dt(2018, 9, 7, 13, 1), 18, dt(2018, 9, 7, 19, 4), False),
-        (dt(2018, 9, 7, 20, 1), 18, dt(2018, 9, 7, 19, 4), True),
+        (dt(2018, 9, 7, 19, 4), 18, dt(2018, 9, 7, 19, 4), True),
         (dt(2018, 9, 8, 13, 1), 18, None, True),
         (dt(2018, 9, 19, 22, 1), 18, None, False),
         (dt(2018, 9, 9, 16, 1), 20, dt(2018, 9, 9, 18, 59), False),


### PR DESCRIPTION
<!---
When opening the PR, your commit messages for a given branch will automatically be
added to the CHANGELOG. Please keep it clear. You can prepend the summary with ``chg``,
``fix`` or ``new`` to insert the message in the correct category.
Adding ``!minor`` or ``!cosmetics`` will cause the commit not to be noted in the
changelog.
--->

# Description
The property issur_melacha_in_effect became True only when now() is later than candle lighting.
Change the condition to be "equal or later" since it should include the exact time of candle lighting.
Updated test to verify this case.

Context:
This change is important for the Home Assistant integration with the PR https://github.com/home-assistant/core/pull/42328. In that HA change we are re-evaluating issur_melacha_in_effect at the moment of candle lighting, and currently it will return False.

# Closes issue(s)

  Fixes: #<issue number>

# Changes included (select only one)

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist

- [x] Code passes tox
