### PR TITLE
add support for erev_shabbat_hag, motzei_shabbat_hag

### DIFF
--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -21,6 +21,7 @@ from hdate.date import HDate
 try:
     import astral
     import astral.sun
+
     _USE_ASTRAL = True
 except ImportError:
     _USE_ASTRAL = False
@@ -88,7 +89,8 @@ class Zmanim(BaseClass):
 
         if _USE_ASTRAL:
             self.astral_observer = astral.Observer(
-                latitude=self.location.latitude, longitude=self.location.longitude)
+                latitude=self.location.latitude, longitude=self.location.longitude
+            )
             self.astral_sun = astral.sun.sun(self.astral_observer, self.date)
 
     def __unicode__(self):
@@ -207,6 +209,40 @@ class Zmanim(BaseClass):
 
         return False
 
+    @property
+    def erev_shabbat_hag(self):
+        """At the given time, return whether erev shabat or chag"""
+        today = HDate(gdate=self.date, diaspora=self.location.diaspora)
+        tomorrow = HDate(
+            gdate=self.date + dt.timedelta(days=1), diaspora=self.location.diaspora
+        )
+
+        if (
+            (tomorrow.is_shabbat or tomorrow.is_yom_tov)
+            and (not today.is_shabbat and not today.is_yom_tov)
+            and (self.time < self.candle_lighting)
+        ):
+            return True
+
+        return False
+
+    @property
+    def motzei_shabbat_hag(self):
+        """At the given time, return whether motzei shabat or chag"""
+        today = HDate(gdate=self.date, diaspora=self.location.diaspora)
+        tomorrow = HDate(
+            gdate=self.date + dt.timedelta(days=1), diaspora=self.location.diaspora
+        )
+
+        if (today.is_shabbat or today.is_yom_tov) and (
+            tomorrow.is_shabbat or tomorrow.is_yom_tov
+        ):
+            return False
+        if (today.is_shabbat or today.is_yom_tov) and (self.time > self.havdalah):
+            return True
+
+        return False
+
     def gday_of_year(self):
         """Return the number of days since January 1 of the given year."""
         return (self.date - dt.date(self.date.year, 1, 1)).days
@@ -285,19 +321,23 @@ class Zmanim(BaseClass):
 
     def _datetime_to_minutes_offest(self, time):
         """Return the time in minutes from 00:00 (utc) for a given time."""
-        return (time.hour * 60 +
-                time.minute +
-                (1 if time.second >= 30 else 0) +
-                int((time.date() - self.date).total_seconds() // 60))
+        return (
+            time.hour * 60
+            + time.minute
+            + (1 if time.second >= 30 else 0)
+            + int((time.date() - self.date).total_seconds() // 60)
+        )
 
     def _get_utc_time_of_transit(self, zenith, rising):
         """Return the time in minutes from 00:00 (utc) for a given sun altitude."""
-        return self._datetime_to_minutes_offest(astral.sun.time_of_transit(
-            self.astral_observer,
-            self.date,
-            zenith,
-            astral.SunDirection.RISING if rising else astral.SunDirection.SETTING
-        ))
+        return self._datetime_to_minutes_offest(
+            astral.sun.time_of_transit(
+                self.astral_observer,
+                self.date,
+                zenith,
+                astral.SunDirection.RISING if rising else astral.SunDirection.SETTING,
+            )
+        )
 
     def get_utc_sun_time_full(self):
         """Return a list of Jewish times for the given location."""

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -28,9 +28,7 @@ def compare_dates(date1, date2):
 
 
 def compare_times(time1, time2):
-    compare_dates(
-        dt.combine(dt.today(), time1),
-        dt.combine(dt.today(), time2))
+    compare_dates(dt.combine(dt.today(), time1), dt.combine(dt.today(), time2))
 
 
 class TestZmanim(object):
@@ -89,13 +87,15 @@ class TestZmanim(object):
             diaspora=True,
         )
 
-        compare_times(Zmanim(date=day, location=location_tz_str).zmanim[
-            "first_stars"
-        ].time(), datetime.time(19, 45))
+        compare_times(
+            Zmanim(date=day, location=location_tz_str).zmanim["first_stars"].time(),
+            datetime.time(19, 45),
+        )
 
-        compare_times(Zmanim(date=day, location=location).zmanim[
-            "first_stars"
-        ].time(), datetime.time(19, 45))
+        compare_times(
+            Zmanim(date=day, location=location).zmanim["first_stars"].time(),
+            datetime.time(19, 45),
+        )
 
     # Times are assumed for NYC.
     CANDLES_TEST = [
@@ -167,3 +167,66 @@ class TestZmanim(object):
             actual = actual.replace(tzinfo=None)
         compare_dates(actual, havdalah)
         assert zmanim.issur_melacha_in_effect == melacha_assur
+
+    # Times are assumed for NYC.
+    MOTZEI_SHABBAT_HAG_TEST = [
+        (dt(2018, 9, 7, 13, 1), 42, False),
+        (dt(2018, 9, 7, 20, 1), 42, False),
+        (dt(2018, 9, 8, 13, 1), 42, False),
+        (dt(2018, 9, 8, 22, 1), 0, True),
+        (dt(2018, 9, 9, 16, 1), 0, False),
+        (dt(2018, 9, 9, 19, 30), 0, False),
+        (dt(2018, 9, 10, 16, 1), 0, False),
+        (dt(2018, 9, 10, 19, 30), 0, False),
+        (dt(2018, 9, 11, 16, 1), 0, False),
+        (dt(2018, 9, 11, 20, 1), 0, True),
+        (dt(2018, 9, 19, 22, 1), 18, True),
+    ]
+
+    @pytest.mark.parametrize(
+        ["now", "offset", "motzei_shabbat_hag"], MOTZEI_SHABBAT_HAG_TEST
+    )
+    def test_motzei_shabbat_hag(self, now, offset, motzei_shabbat_hag):
+        location_tz_str = Location(
+            name="New York",
+            latitude=NYC_LAT,
+            longitude=NYC_LNG,
+            timezone="America/New_York",
+            diaspora=True,
+        )
+        # Use a constant offset for Havdalah for unit test stability.
+        zmanim = Zmanim(date=now, location=location_tz_str, havdalah_offset=offset)
+        assert zmanim.motzei_shabbat_hag == motzei_shabbat_hag
+
+    # Times are assumed for NYC.
+    EREV_SHABBAT_HAG_TEST = [
+        (dt(2018, 9, 7, 13, 1), 42, True),  # fri
+        (dt(2018, 9, 7, 20, 1), 42, False),
+        (dt(2018, 9, 8, 13, 1), 42, False),  # sat
+        (dt(2018, 9, 8, 20, 1), 0, False),
+        (dt(2018, 9, 9, 16, 1), 0, True),  # erev rosh hashana
+        (dt(2018, 9, 9, 19, 30), 0, False),
+        (dt(2018, 9, 10, 16, 1), 0, False),  # rosh hashana I
+        (dt(2018, 9, 10, 19, 30), 0, False),
+        (dt(2018, 9, 11, 16, 1), 0, False),  # rosh hashana II
+        (dt(2018, 9, 11, 20, 1), 0, False),
+        (dt(2018, 9, 18, 13, 1), 18, True),  # erev yom kipur
+        (dt(2018, 9, 18, 22, 1), 18, False),
+        (dt(2018, 9, 19, 13, 1), 18, False),
+        (dt(2018, 9, 19, 22, 1), 18, False),
+    ]
+
+    @pytest.mark.parametrize(
+        ["now", "offset", "erev_shabbat_hag"], EREV_SHABBAT_HAG_TEST
+    )
+    def test_erev_shabbat_hag(self, now, offset, erev_shabbat_hag):
+        location_tz_str = Location(
+            name="New York",
+            latitude=NYC_LAT,
+            longitude=NYC_LNG,
+            timezone="America/New_York",
+            diaspora=True,
+        )
+        # Use a constant offset for Havdalah for unit test stability.
+        zmanim = Zmanim(date=now, location=location_tz_str, havdalah_offset=offset)
+        assert zmanim.erev_shabbat_hag == erev_shabbat_hag


### PR DESCRIPTION
# Description
Add support for boolean to get is erev shabat or hag, and also if motzei shabat or hag (will take into account if there is a double hag, shabat with hag)


# Changes included (select only one)

- [ ] Bugfix (non-breaking change that solves an issue)
- [ X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist

- [ X] Code passes tox
