### PR TITLE
Fix issues with get_holidays_for_year()

### DIFF
--- a/hdate/date.py
+++ b/hdate/date.py
@@ -377,11 +377,15 @@ class HDate(BaseClass):
             for date_instance in holiday_dates_cross_product(holiday)
             if len(holiday.date) >= 2
         ]
+        is_leap_year = self.year_size() > 380
         # Filter any special cases defined by True/False functions
         holidays_list = [
             (holiday, date)
             for (holiday, date) in holidays_list
             if all(func(date) for func in holiday.date_functions_list)
+            # Don't return two copies of Purim.
+            if date.hdate.month
+            not in ([Months.ADAR] if is_leap_year else [Months.ADAR_I, Months.ADAR_II])
         ]
         return holidays_list
 

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -4,6 +4,7 @@ Jewish calendrical date and times for a given location.
 HDate calculates and generates a representation either in English or Hebrew
 of the Jewish calendrical date and times for a given location
 """
+
 import datetime
 import logging
 from itertools import chain, product
@@ -345,13 +346,6 @@ class HDate(BaseClass):
                 holiday for holiday in holidays_list if holiday.type in types
             ]
 
-        # Filter any special cases defined by True/False functions
-        holidays_list = [
-            holiday
-            for holiday in holidays_list
-            if all(func(self) for func in holiday.date_functions_list)
-        ]
-
         _LOGGER.debug(
             "Holidays after filters have been applied: %s",
             [holiday.name for holiday in holidays_list],
@@ -382,6 +376,12 @@ class HDate(BaseClass):
             for holiday in holidays_list
             for date_instance in holiday_dates_cross_product(holiday)
             if len(holiday.date) >= 2
+        ]
+        # Filter any special cases defined by True/False functions
+        holidays_list = [
+            (holiday, date)
+            for (holiday, date) in holidays_list
+            if all(func(date) for func in holiday.date_functions_list)
         ]
         return holidays_list
 

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -377,15 +377,11 @@ class HDate(BaseClass):
             for date_instance in holiday_dates_cross_product(holiday)
             if len(holiday.date) >= 2
         ]
-        is_leap_year = self.year_size() > 380
         # Filter any special cases defined by True/False functions
         holidays_list = [
             (holiday, date)
             for (holiday, date) in holidays_list
             if all(func(date) for func in holiday.date_functions_list)
-            # Don't return two copies of Purim.
-            if date.hdate.month
-            not in ([Months.ADAR] if is_leap_year else [Months.ADAR_I, Months.ADAR_II])
         ]
         return holidays_list
 

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -373,6 +373,19 @@ def move_if_not_on_dow(original, replacement, dow_not_orig, dow_replacement):
     )
 
 
+def correct_adar():
+    """
+    Return a lambda function.
+
+    Lambda checks that the value of the month returned is correct depending on whether
+    it's a leap year.
+    """
+    return lambda x: (
+        (x.hdate.month == Months.ADAR and x.year_size() < 380)
+        or (x.hdate.month in [Months.ADAR_I, Months.ADAR_II] and x.year_size() > 380)
+    )
+
+
 HOLIDAY = namedtuple(
     "HOLIDAY",
     ["type", "name", "date", "israel_diaspora", "date_functions_list", "description"],
@@ -545,7 +558,7 @@ HOLIDAYS = (
         "taanit_esther",
         ([11, 13], [Months.ADAR, Months.ADAR_II]),
         "",
-        [move_if_not_on_dow(13, 11, 5, 3)],
+        [move_if_not_on_dow(13, 11, 5, 3), correct_adar()],
         LANG("Jeûne d'Esther", "Ta'anit Esther", DESC("תענית אסתר", "תענית אסתר")),
     ),
     HOLIDAY(
@@ -553,7 +566,7 @@ HOLIDAYS = (
         "purim",
         (14, [Months.ADAR, Months.ADAR_II]),
         "",
-        [],
+        [correct_adar()],
         LANG("Pourim", "Purim", DESC("פורים", "פורים")),
     ),
     HOLIDAY(
@@ -561,7 +574,7 @@ HOLIDAYS = (
         "shushan_purim",
         (15, [Months.ADAR, Months.ADAR_II]),
         "",
-        [],
+        [correct_adar()],
         LANG("Pourim Shoushan", "Shushan Purim", DESC("שושן פורים", "שושן פורים")),
     ),
     HOLIDAY(
@@ -790,7 +803,7 @@ HOLIDAYS = (
         "memorial_day_unknown",
         (7, [Months.ADAR, Months.ADAR_II]),
         "ISRAEL",
-        [],
+        [correct_adar()],
         LANG(
             "Jour du souvenir",
             "Memorial day for fallen whose place of burial is unknown",

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -146,6 +146,20 @@ class TestHDate:
 class TestSpecialDays:
     """Test HDate in terms of special days."""
 
+    # Test against both a leap year and non-leap year
+    @pytest.mark.parametrize(("year"), ((5783, 5784)))
+    def test_get_holidays_for_year(self, year):
+        """Test that get_holidays_for_year() returns every holiday."""
+        cur_date = HDate(heb_date=HebrewDate(year, 1, 1))
+        expected_holiday_map = {
+            date.gdate: entry for (entry, date) in cur_date.get_holidays_for_year()
+        }
+        while cur_date.hdate.year == year:
+            actual_holiday = cur_date.holiday_name
+            if actual_holiday:
+                assert actual_holiday == expected_holiday_map[cur_date.gdate].name
+            cur_date = cur_date.next_day
+
     NON_MOVING_HOLIDAYS = [
         ((1, 1), "rosh_hashana_i"),
         ((2, 1), "rosh_hashana_ii"),

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -160,6 +160,18 @@ class TestSpecialDays:
                 assert actual_holiday == expected_holiday_map[cur_date.gdate].name
             cur_date = cur_date.next_day
 
+    def test_get_holidays_for_year_non_leap_year(self):
+        """Test that get_holidays_for_year() returns consistent months."""
+        base_date = HDate(heb_date=HebrewDate(5783, 1, 1))
+        for entry, date in base_date.get_holidays_for_year():
+            assert date.hdate.month not in [Months.ADAR_I, Months.ADAR_II]
+
+    def test_get_holidays_for_year_leap_year(self):
+        """Test that get_holidays_for_year() returns consistent months."""
+        base_date = HDate(heb_date=HebrewDate(5784, 1, 1))
+        for entry, date in base_date.get_holidays_for_year():
+            assert date.hdate.month != Months.ADAR
+
     NON_MOVING_HOLIDAYS = [
         ((1, 1), "rosh_hashana_i"),
         ((2, 1), "rosh_hashana_ii"),


### PR DESCRIPTION
<!---
When opening the PR, your commit messages for a given branch will automatically be
added to the CHANGELOG. Please keep it clear. You can prepend the summary with ``chg``,
``fix`` or ``new`` to insert the message in the correct category.
Adding ``!minor`` or ``!cosmetics`` will cause the commit not to be noted in the
changelog.
--->

# Description

`get_holidays_for_year()` would return two copies of Purim, and would entirely miss most fast days.  This fixes that, and adds thorough test coverage.

# Closes issue(s)

  Fixes: 

# Changes included (select only one)

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist

- [x] Code passes tox
