### PR TITLE
Allow locations to the north of 50 degrees latitude

### DIFF
--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     _USE_ASTRAL = False
 
-
+MAX_LATITUDE_ASTRAL = 50.0
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -84,7 +84,7 @@ class Zmanim(BaseClass):  # pylint: disable=too-many-instance-attributes
         _LOGGER.debug("Resetting timezone to UTC for calculations")
         self.time = location.timezone.localize(self.time).astimezone(pytz.utc)
 
-        if _USE_ASTRAL:
+        if _USE_ASTRAL and (location.latitude <= MAX_LATITUDE_ASTRAL):
             self.astral_observer = astral.Observer(
                 latitude=self.location.latitude, longitude=self.location.longitude
             )
@@ -336,7 +336,7 @@ class Zmanim(BaseClass):  # pylint: disable=too-many-instance-attributes
 
     def get_utc_sun_time_full(self):
         """Return a list of Jewish times for the given location."""
-        if not _USE_ASTRAL:
+        if (not _USE_ASTRAL) or (self.location.latitude > MAX_LATITUDE_ASTRAL):
             sunrise, sunset = self._get_utc_sun_time_deg(90.833)
             first_light, _ = self._get_utc_sun_time_deg(106.1)
             talit, _ = self._get_utc_sun_time_deg(101.0)


### PR DESCRIPTION
<!---
When opening the PR, your commit messages for a given branch will automatically be
added to the CHANGELOG. Please keep it clear. You can prepend the summary with ``chg``,
``fix`` or ``new`` to insert the message in the correct category.
Adding ``!minor`` or ``!cosmetics`` will cause the commit not to be noted in the
changelog.
--->

# Description
Calculating times at latitudes greater than 50 degrees  (Amsterdam, London and more) causes problems for astral.
This fix reverts to using the old method albeit less precise but providing a wider coverage.

# Closes issue(s)

  Fixes: #96
  This is related to home-assistant/core#118930 and home-assistant/core#51641

# Changes included (select only one)

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist

- [ ] Code passes tox
