### PR TITLE
Add Rosh Chodesh holiday

### DIFF
--- a/hdate/date.py
+++ b/hdate/date.py
@@ -152,9 +152,11 @@ class HDate:
 
         In case none exists will return None.
         """
-        entry = self._holiday_entry()
-        desc = entry.description
-        return desc.hebrew.long if self.hebrew else desc.english
+        entries = self._holiday_entries()
+        return ", ".join(
+            entry.description.hebrew.long if self.hebrew else entry.description.english
+            for entry in entries
+        )
 
     @property
     def is_shabbat(self):
@@ -183,16 +185,24 @@ class HDate:
     @property
     def holiday_type(self):
         """Return the holiday type if exists."""
-        entry = self._holiday_entry()
-        return entry.type
+        entries = self._holiday_entries()
+        if len(entries) > 1:
+            return [entry.type for entry in entries]
+        if len(entries) == 1:
+            return entries[0].type
+        return ""
 
     @property
     def holiday_name(self):
         """Return the holiday name which is good for programmatic use."""
-        entry = self._holiday_entry()
-        return entry.name
+        entries = self._holiday_entries()
+        if len(entries) > 1:
+            return [entry.name for entry in entries]
+        if len(entries) == 1:
+            return entries[0].name
+        return ""
 
-    def _holiday_entry(self):
+    def _holiday_entries(self):
         """Return the abstract holiday information from holidays table."""
         holidays_list = self.get_holidays_for_year()
         holidays_list = [
@@ -200,10 +210,9 @@ class HDate:
             for holiday, holiday_hdate in holidays_list
             if holiday_hdate.hdate == self.hdate
         ]
-        assert len(holidays_list) <= 1
 
         # If anything is left return it, otherwise return the "NULL" holiday
-        return holidays_list[0] if holidays_list else htables.HOLIDAYS[0]
+        return holidays_list
 
     def short_kislev(self):
         """Return whether this year has a short Kislev or not."""

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -218,6 +218,10 @@ class HDate:
         """Return whether this year has a short Kislev or not."""
         return self.year_size() in [353, 383]
 
+    def long_cheshvan(self):
+        """Return whether this year has a long Cheshvan or not."""
+        return self.year_size() in [355, 385]
+
     @property
     def dow(self):
         """Return Hebrew day of week Sunday = 1, Saturday = 7."""

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -387,6 +387,33 @@ def correct_adar():
     )
 
 
+def legal_month_length():
+    """
+    Return a lambda function.
+
+    Lambda checks that the length for the provided month is legal
+    """
+    return lambda x: (
+        x.hdate.day == 29  # 29 is always legal
+        or x.hdate.day == 30
+        and x.hdate.month
+        in [
+            Months.TISHREI,
+            Months.SHVAT,
+            Months.ADAR_I,
+            Months.NISAN,
+            Months.SIVAN,
+            Months.AV,
+        ]
+        or x.hdate.day == 30
+        and x.long_cheshvan()
+        and x.hdate.month == Months.MARCHESHVAN
+        or x.hdate.day == 30
+        and not x.short_kislev()
+        and x.hdate.month == Months.KISLEV
+    )
+
+
 HOLIDAY = namedtuple(
     "HOLIDAY",
     ["type", "name", "date", "israel_diaspora", "date_functions_list", "description"],
@@ -841,7 +868,7 @@ HOLIDAYS = (
         "rosh_chodesh",
         ([1, 30], [month for month in Months if month != Months.TISHREI]),
         "",
-        [correct_adar()],
+        [correct_adar(), legal_month_length()],
         LANG("Rosh Chodesh", "Rosh Chodesh", DESC("ראש חודש", "ראש חודש")),
     ),
 )

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -381,7 +381,8 @@ def correct_adar():
     it's a leap year.
     """
     return lambda x: (
-        (x.hdate.month == Months.ADAR and not x.is_leap_year)
+        (x.hdate.month not in [Months.ADAR, Months.ADAR_I, Months.ADAR_II])
+        or (x.hdate.month == Months.ADAR and not x.is_leap_year)
         or (x.hdate.month in [Months.ADAR_I, Months.ADAR_II] and x.is_leap_year)
     )
 

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -387,6 +387,11 @@ def correct_adar():
     )
 
 
+def not_rosh_chodesh():
+    """The 1st of Tishrei is not Rosh Chodesh."""
+    return lambda x: not (x.hdate.month == Months.TISHREI and x.hdate.day == 1)
+
+
 def legal_month_length():
     """
     Return a lambda function.
@@ -866,9 +871,9 @@ HOLIDAYS = (
     HOLIDAY(
         HolidayTypes.ROSH_CHODESH,
         "rosh_chodesh",
-        ([1, 30], [month for month in Months if month != Months.TISHREI]),
+        ([1, 30], list(Months)),
         "",
-        [correct_adar(), legal_month_length()],
+        [correct_adar(), legal_month_length(), not_rosh_chodesh()],
         LANG("Rosh Chodesh", "Rosh Chodesh", DESC("ראש חודש", "ראש חודש")),
     ),
 )

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -405,6 +405,7 @@ class HolidayTypes(Enum):
     MINOR_HOLIDAY = 7
     MEMORIAL_DAY = 8
     ISRAEL_NATIONAL_HOLIDAY = 9
+    ROSH_CHODESH = 10
 
 
 HOLIDAYS = (
@@ -833,6 +834,14 @@ HOLIDAYS = (
             "Zeev Zhabotinsky day",
             DESC("יום ז'בוטינסקי", "יום ז'בוטינסקי"),
         ),
+    ),
+    HOLIDAY(
+        HolidayTypes.ROSH_CHODESH,
+        "rosh_chodesh",
+        ([1, 30], [month for month in Months if month != Months.TISHREI]),
+        "",
+        [],
+        LANG("Rosh Chodesh", "Rosh Chodesh", DESC("ראש חודש", "ראש חודש")),
     ),
 )
 

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -840,7 +840,7 @@ HOLIDAYS = (
         "rosh_chodesh",
         ([1, 30], [month for month in Months if month != Months.TISHREI]),
         "",
-        [],
+        [correct_adar()],
         LANG("Rosh Chodesh", "Rosh Chodesh", DESC("ראש חודש", "ראש חודש")),
     ),
 )

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -435,6 +435,14 @@ class TestSpecialDays:
             else:
                 assert myhdate.holiday_name == holiday
 
+    def test_get_tishrei_rosh_chodesh(self):
+        """30th of Tishrei should be Rosh Chodesh"""
+        year = random.randint(5000, 6000)
+        myhdate = HDate(heb_date=HebrewDate(year, Months.TISHREI, 30))
+        assert myhdate.holiday_name == "rosh_chodesh"
+        myhdate = HDate(heb_date=HebrewDate(year, Months.TISHREI, 1))
+        assert myhdate.holiday_name == "rosh_hashana_i"
+
     @pytest.mark.parametrize("execution_number", list(range(10)))
     def test_get_omer_day(self, execution_number, rand_hdate):
         """Test value of the Omer."""

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -207,7 +207,7 @@ class TestSpecialDays:
         ((27, 3), "chanukah"),
         ((28, 3), "chanukah"),
         ((29, 3), "chanukah"),
-        ((1, 4), "chanukah"),
+        ((1, 4), ["chanukah", "rosh_chodesh"]),
         ((2, 4), "chanukah"),
         ((10, 4), "asara_btevet"),
         ((15, 5), "tu_bshvat"),


### PR DESCRIPTION
# Description

Add Rosh Chodesh to holiday if the date is 1, or 30 in the month.
**Note:** This breaks the current behavior where holiday always returns a string, it now can also return a list of multiple holidays (e.g. chanukah + rosh chodesh)
 
# Closes issue(s)

  Fixes: #51
  Supports: home-assistant/core#29410, home-assistant/core#45137

# Changes included

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible)

# Checklist

- [x] Code passes tox
