### PR TITLE
Improve HebrewDate API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ htmlcov/
 .tox
 .cache
 .pytest_cache/
+.hypothesis/
 
 # Profiling data
 prof/

--- a/hdate/converters.py
+++ b/hdate/converters.py
@@ -1,85 +1,10 @@
-"""Methods for going back and forth between various calendars."""
+"""Methods for going back and forth between Gregorian date and Julian day."""
 
-import datetime
+import datetime as dt
 from typing import Union
 
-from hdate.hebrew_date import HebrewDate
-from hdate.htables import Months
 
-
-def get_chalakim(hours: int, parts: int) -> int:
-    """Return the number of total parts (chalakim)."""
-    return (hours * PARTS_IN_HOUR) + parts
-
-
-PARTS_IN_HOUR = 1080
-PARTS_IN_DAY = 24 * PARTS_IN_HOUR
-PARTS_IN_WEEK = 7 * PARTS_IN_DAY
-PARTS_IN_MONTH = PARTS_IN_DAY + get_chalakim(12, 793)  # Fix for regular month
-
-
-def _days_from_3744(hebrew_year: int) -> int:
-    """Return: Number of days since 3,1,3744."""
-    # Start point for calculation is Molad new year 3744 (16BC)
-    years_from_3744 = hebrew_year - 3744
-    molad_3744 = get_chalakim(1 + 6, 779)  # Molad 3744 + 6 hours in parts
-
-    # Time in months
-
-    # Number of leap months
-    leap_months = (years_from_3744 * 7 + 1) // 19
-    leap_left = (years_from_3744 * 7 + 1) % 19  # Months left of leap cycle
-    months = years_from_3744 * 12 + leap_months  # Total Number of months
-
-    # Time in parts and days
-    # Molad This year + Molad 3744 - corrections
-    parts = months * PARTS_IN_MONTH + molad_3744
-    # 28 days in month + corrections
-    days = months * 28 + parts // PARTS_IN_DAY - 2
-
-    # Time left for round date in corrections
-    # 28 % 7 = 0 so only corrections counts
-    parts_left_in_week = parts % PARTS_IN_WEEK
-    parts_left_in_day = parts % PARTS_IN_DAY
-    week_day = parts_left_in_week // PARTS_IN_DAY
-
-    # pylint: disable=too-many-boolean-expressions
-    # pylint-comment: Splitting the 'if' below might create a bug in case
-    # the order is not kept.
-
-    # Molad ד"ר ט"ג
-    if (
-        (
-            leap_left < 12
-            and week_day == 3
-            and parts_left_in_day >= get_chalakim(9 + 6, 204)
-        )
-        or
-        # Molad ט"פקת ו"טב
-        (
-            leap_left < 7
-            and week_day == 2
-            and parts_left_in_day >= get_chalakim(15 + 6, 589)
-        )
-    ):
-        days += 1
-        week_day += 1
-
-    # pylint: enable=too-many-boolean-expressions
-
-    # ADU
-    if week_day in (1, 4, 6):
-        days += 1
-
-    return days
-
-
-def get_size_of_hebrew_year(hebrew_year: int) -> int:
-    """Return: total days in hebrew year."""
-    return _days_from_3744(hebrew_year + 1) - _days_from_3744(hebrew_year)
-
-
-def gdate_to_jdn(date: Union[datetime.date, datetime.datetime]) -> int:
+def gdate_to_jdn(date: Union[dt.date, dt.datetime]) -> int:
     """
     Compute Julian day from Gregorian day, month and year.
 
@@ -99,41 +24,7 @@ def gdate_to_jdn(date: Union[datetime.date, datetime.datetime]) -> int:
     return jdn
 
 
-def hdate_to_jdn(date: HebrewDate) -> int:
-    """
-    Compute Julian day from Hebrew day, month and year.
-
-    Return: julian day number,
-            1 of tishrey julians,
-            1 of tishrey julians next year
-    """
-    day = date.day
-    month = date.month.value if isinstance(date.month, Months) else date.month
-
-    if date.month == Months.ADAR_I:
-        month = 6
-    if date.month == Months.ADAR_II:
-        month = 6
-        day += 30
-
-    # Calculate days since 1,1,3744
-    day = _days_from_3744(date.year) + (59 * (month - 1) + 1) // 2 + day
-
-    # length of year
-    length_of_year = get_size_of_hebrew_year(date.year)
-    # Special cases for this year
-    if length_of_year % 10 > 4 and month > 2:  # long Heshvan
-        day += 1
-    if length_of_year % 10 < 4 and month > 3:  # short Kislev
-        day -= 1
-    if length_of_year > 365 and month > 6:  # leap year
-        day += 30
-
-    # adjust to julian
-    return day + 1715118
-
-
-def jdn_to_gdate(jdn: int) -> datetime.date:
+def jdn_to_gdate(jdn: int) -> dt.date:
     """
     Convert from the Julian day to the Gregorian day.
 
@@ -157,57 +48,4 @@ def jdn_to_gdate(jdn: int) -> datetime.date:
     month = j + 2 - (12 * l)
     year = 100 * (n - 49) + i + l  # that's a lower-case L
 
-    return datetime.date(year, month, day)
-
-
-def jdn_to_hdate(jdn: int) -> HebrewDate:
-    """Convert from the Julian day to the Hebrew day."""
-    # calculate Gregorian date
-    date = jdn_to_gdate(jdn)
-
-    # Guess Hebrew year is Gregorian year + 3760
-    year = date.year + 3760
-
-    jdn_tishrey1 = hdate_to_jdn(HebrewDate(year, Months.TISHREI, 1))
-    jdn_tishrey1_next_year = hdate_to_jdn(HebrewDate(year + 1, Months.TISHREI, 1))
-
-    # Check if computed year was underestimated
-    if jdn_tishrey1_next_year <= jdn:
-        year = year + 1
-        jdn_tishrey1 = jdn_tishrey1_next_year
-        jdn_tishrey1_next_year = hdate_to_jdn(HebrewDate(year + 1, Months.TISHREI, 1))
-
-    size_of_year = get_size_of_hebrew_year(year)
-
-    # days into this year, first month 0..29
-    days = jdn - jdn_tishrey1
-
-    # last 8 months always have 236 days
-    if days >= (size_of_year - 236):  # in last 8 months
-        days = days - (size_of_year - 236)
-        month = days * 2 // 59
-        day = days - (month * 59 + 1) // 2 + 1
-
-        month = month + 4 + 1
-
-        # if leap
-        if size_of_year > 355 and month <= 6:
-            month = month + 8
-    else:  # in 4-5 first months
-        # Special cases for this year
-        if size_of_year % 10 > 4 and days == 59:  # long Heshvan (day 30)
-            month = 1
-            day = 30
-        elif size_of_year % 10 > 4 and days > 59:  # long Heshvan
-            month = (days - 1) * 2 // 59
-            day = days - (month * 59 + 1) // 2
-        elif size_of_year % 10 < 4 and days > 87:  # short kislev
-            month = (days + 1) * 2 // 59
-            day = days - (month * 59 + 1) // 2 + 2
-        else:  # regular months
-            month = days * 2 // 59
-            day = days - (month * 59 + 1) // 2 + 1
-
-        month = month + 1
-
-    return HebrewDate(year, Months(month), day)
+    return dt.date(year, month, day)

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -205,19 +205,11 @@ class HDate(TranslatorMixin):
         holidays_list = [
             holiday
             for holiday, holiday_hdate in _holidays_list
-            if holiday_hdate.hdate == self.hdate
+            if holiday_hdate == self.hdate
         ]
 
         # If anything is left return it, otherwise return the "NULL" holiday
         return holidays_list
-
-    def short_kislev(self) -> bool:
-        """Return whether this year has a short Kislev or not."""
-        return self.year_size() in [353, 383]
-
-    def long_cheshvan(self) -> bool:
-        """Return whether this year has a long Cheshvan or not."""
-        return self.year_size() in [355, 385]
 
     @property
     def dow(self) -> htables.Days:
@@ -332,7 +324,7 @@ class HDate(TranslatorMixin):
 
     def get_holidays_for_year(
         self, types: Optional[list[HolidayTypes]] = None
-    ) -> list[tuple[Holiday, HDate]]:
+    ) -> list[tuple[Holiday, HebrewDate]]:
         """Get all the actual holiday days for a given HDate's year.
 
         If specified, use the list of types to limit the holidays returned.
@@ -374,13 +366,7 @@ class HDate(TranslatorMixin):
         _holidays_list_1 = [
             (
                 holiday,
-                HDate(
-                    heb_date=HebrewDate(
-                        self.hdate.year, date_instance[1], date_instance[0]
-                    ),
-                    diaspora=self.diaspora,
-                    language=self._language,
-                ),
+                HebrewDate(year=0, month=date_instance[1], day=date_instance[0]),
             )
             for holiday in _holidays_list
             for date_instance in holiday_dates_cross_product(holiday)
@@ -395,7 +381,7 @@ class HDate(TranslatorMixin):
         return holidays_list
 
     @property
-    def upcoming_yom_tov(self) -> "HDate":
+    def upcoming_yom_tov(self) -> HDate:
         """Find the next upcoming yom tov (i.e. no-melacha holiday).
 
         If it is currently the day of yom tov (irrespective of zmanim), returns
@@ -415,12 +401,14 @@ class HDate(TranslatorMixin):
         holidays_list = [
             holiday_hdate
             for _, holiday_hdate in chain(this_year, next_year)
-            if holiday_hdate >= self
+            if holiday_hdate >= self.hdate
         ]
 
-        holidays_list.sort(key=lambda h: h.gdate)
+        holidays_list.sort(key=lambda h: h.to_gdate())
 
-        return holidays_list[0]
+        return HDate(
+            heb_date=holidays_list[0], diaspora=self.diaspora, language=self._language
+        )
 
     def get_reading(self) -> htables.Parasha:
         """Return number of hebrew parasha."""

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -7,7 +7,7 @@ of the Jewish calendrical date and times for a given location
 
 from __future__ import annotations
 
-import datetime
+import datetime as dt
 import logging
 from itertools import chain, product
 from typing import Any, Generator, Optional, Union, cast
@@ -38,7 +38,7 @@ class HDate(TranslatorMixin):
 
     def __init__(
         self,
-        gdate: datetime.date = datetime.date.today(),
+        gdate: dt.date = dt.date.today(),
         diaspora: bool = False,
         language: str = "hebrew",
         heb_date: Optional[HebrewDate] = None,
@@ -118,14 +118,14 @@ class HDate(TranslatorMixin):
         self._hdate = date
 
     @property
-    def gdate(self) -> datetime.date:
+    def gdate(self) -> dt.date:
         """Return the Gregorian date for the given Hebrew date object."""
         if self._last_updated == "gdate":
             return self._gdate
         return self._hdate.to_gdate()
 
     @gdate.setter
-    def gdate(self, date: datetime.date) -> None:
+    def gdate(self, date: dt.date) -> None:
         """Set the Gregorian date for the given Hebrew date object."""
         self._last_updated = "gdate"
         self._gdate = date
@@ -252,12 +252,12 @@ class HDate(TranslatorMixin):
     @property
     def next_day(self) -> "HDate":
         """Return the HDate for the next day."""
-        return HDate(self.gdate + datetime.timedelta(1), self.diaspora, self._language)
+        return HDate(self.gdate + dt.timedelta(1), self.diaspora, self._language)
 
     @property
     def previous_day(self) -> "HDate":
         """Return the HDate for the previous day."""
-        return HDate(self.gdate + datetime.timedelta(-1), self.diaspora, self._language)
+        return HDate(self.gdate + dt.timedelta(-1), self.diaspora, self._language)
 
     @property
     def upcoming_shabbat(self) -> "HDate":
@@ -268,7 +268,7 @@ class HDate(TranslatorMixin):
         if self.is_shabbat:
             return self
         # If it's Sunday, fast forward to the next Shabbat.
-        saturday = self.gdate + datetime.timedelta((12 - self.gdate.weekday()) % 7)
+        saturday = self.gdate + dt.timedelta((12 - self.gdate.weekday()) % 7)
         return HDate(saturday, diaspora=self.diaspora, language=self._language)
 
     @property

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -175,11 +175,6 @@ class HDate(TranslatorMixin):
         return self.holiday_type == HolidayTypes.YOM_TOV
 
     @property
-    def is_leap_year(self) -> bool:
-        """Return True if this date's year is a leap year."""
-        return self.hdate.is_leap_year()
-
-    @property
     def holiday_type(self) -> Union[HolidayTypes, list[HolidayTypes]]:
         """Return the holiday type if exists."""
         entries = self._holiday_entries()

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -52,7 +52,7 @@ class HDate(TranslatorMixin):
 
         if heb_date is None:
             self.gdate = gdate
-            self._hdate = conv.jdn_to_hdate(self._jdn)
+            self._hdate = HebrewDate.from_jdn(self._jdn)
         else:
             self.hdate = heb_date
             self._gdate = conv.jdn_to_gdate(self._jdn)
@@ -107,7 +107,7 @@ class HDate(TranslatorMixin):
         """Return the hebrew date."""
         if self._last_updated == "hdate":
             return self._hdate
-        return conv.jdn_to_hdate(self._jdn)
+        return HebrewDate.from_jdn(self._jdn)
 
     @hdate.setter
     def hdate(self, date: HebrewDate) -> None:
@@ -118,7 +118,7 @@ class HDate(TranslatorMixin):
 
         self._last_updated = "hdate"
         self._hdate = date
-        self._jdn = conv.hdate_to_jdn(date)
+        self._jdn = date.to_jdn()
 
     @property
     def gdate(self) -> datetime.date:
@@ -234,23 +234,23 @@ class HDate(TranslatorMixin):
 
     def year_size(self) -> int:
         """Return the size of the given Hebrew year."""
-        return conv.get_size_of_hebrew_year(self.hdate.year)
+        return HebrewDate.year_size(self.hdate.year)
 
     def rosh_hashana_dow(self) -> int:
         """Return the Hebrew day of week for Rosh Hashana."""
-        jdn = conv.hdate_to_jdn(HebrewDate(self.hdate.year, Months.TISHREI, 1))
+        jdn = HebrewDate(self.hdate.year, Months.TISHREI, 1).to_jdn()
         return (jdn + 1) % 7 + 1
 
     def pesach_dow(self) -> int:
         """Return the first day of week for Pesach."""
-        jdn = conv.hdate_to_jdn(HebrewDate(self.hdate.year, Months.NISAN, 15))
+        jdn = HebrewDate(self.hdate.year, Months.NISAN, 15).to_jdn()
         return (jdn + 1) % 7 + 1
 
     @property
     def omer_day(self) -> int:
         """Return the day of the Omer."""
         first_omer_day = HebrewDate(self.hdate.year, Months.NISAN, 16)
-        omer_day = self._jdn - conv.hdate_to_jdn(first_omer_day) + 1
+        omer_day = self._jdn - first_omer_day.to_jdn() + 1
         if not 0 < omer_day < 50:
             return 0
         return omer_day
@@ -450,7 +450,7 @@ class HDate(TranslatorMixin):
 
         # Number of days since rosh hashana
         rosh_hashana = HebrewDate(self.hdate.year, Months.TISHREI, 1)
-        days = self._jdn - conv.hdate_to_jdn(rosh_hashana)
+        days = (self.hdate - rosh_hashana).days
         # Number of weeks since rosh hashana
         weeks = (days + self.rosh_hashana_dow() - 1) // 7
         _LOGGER.debug("Since Rosh Hashana - Days: %d, Weeks %d", days, weeks)

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -177,7 +177,7 @@ class HDate(TranslatorMixin):
     @property
     def is_leap_year(self) -> bool:
         """Return True if this date's year is a leap year."""
-        return self.hdate.year % 19 in [0, 3, 6, 8, 11, 14, 17]
+        return self.hdate.is_leap_year()
 
     @property
     def holiday_type(self) -> Union[HolidayTypes, list[HolidayTypes]]:

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -232,16 +232,6 @@ class HDate(TranslatorMixin):
         """Return the size of the given Hebrew year."""
         return HebrewDate.year_size(self.hdate.year)
 
-    def rosh_hashana_dow(self) -> int:
-        """Return the Hebrew day of week for Rosh Hashana."""
-        jdn = HebrewDate(self.hdate.year, Months.TISHREI, 1).to_jdn()
-        return (jdn + 1) % 7 + 1
-
-    def pesach_dow(self) -> int:
-        """Return the first day of week for Pesach."""
-        jdn = HebrewDate(self.hdate.year, Months.NISAN, 15).to_jdn()
-        return (jdn + 1) % 7 + 1
-
     @property
     def omer_day(self) -> int:
         """Return the day of the Omer."""
@@ -437,9 +427,9 @@ class HDate(TranslatorMixin):
         _year_type = (self.year_size() % 10) - 3
         year_type = (
             self.diaspora * 1000
-            + self.rosh_hashana_dow() * 100
+            + HebrewDate(self.hdate.year, Months.TISHREI, 1).dow() * 100
             + _year_type * 10
-            + self.pesach_dow()
+            + HebrewDate(self.hdate.year, Months.NISAN, 15).dow()
         )
 
         _LOGGER.debug("Year type: %d", year_type)
@@ -448,7 +438,7 @@ class HDate(TranslatorMixin):
         rosh_hashana = HebrewDate(self.hdate.year, Months.TISHREI, 1)
         days = (self.hdate - rosh_hashana).days
         # Number of weeks since rosh hashana
-        weeks = (days + self.rosh_hashana_dow() - 1) // 7
+        weeks = (days + rosh_hashana.dow() - 1) // 7
         _LOGGER.debug("Since Rosh Hashana - Days: %d, Weeks %d", days, weeks)
 
         # If it's currently Simchat Torah, return VeZot Haberacha.

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -60,19 +60,19 @@ class HebrewDate(TranslatorMixin):
         if not isinstance(other, dt.timedelta):
             return NotImplemented
         days = other.days  # Number of days to add
-        day, month, year = self.day, self.month, self.year
+        new = HebrewDate(self.day, self.month, self.year)
         while days > 0:
-            days_left_in_month = self.get_month_days(Months(month), year) - day
+            days_left_in_month = new.get_month_days(Months(new.month)) - new.day
             if days_left_in_month > days:
-                day += days
+                new.day += days
                 break
             days -= days_left_in_month
-            day = 1
-            month = self.get_next_month(Months(month), year)
-            if month == Months.TISHREI:
-                year += 1
+            new.day = 1
+            new.month = self.get_next_month(Months(new.month), new.year)
+            if new.month == Months.TISHREI:
+                new.year += 1
 
-        return HebrewDate(year, month, day)
+        return new
 
     def __sub__(self, other: object) -> dt.timedelta:
         if not isinstance(other, HebrewDate):
@@ -230,7 +230,7 @@ class HebrewDate(TranslatorMixin):
             hebrew_year
         )
 
-    def get_month_days(self, month: Months, year: int) -> int:
+    def get_month_days(self, month: Months) -> int:
         """Return the number of days in a month."""
         if month in (
             Months.TISHREI,
@@ -251,18 +251,19 @@ class HebrewDate(TranslatorMixin):
         ):
             return 29
         if month == Months.KISLEV:
-            return 29 if HebrewDate.year_size(year) in (353, 383) else 30
+            return 29 if HebrewDate.year_size(self.year) in (353, 383) else 30
         if month == Months.MARCHESHVAN:
-            return 30 if HebrewDate.year_size(year) in (355, 385) else 29
+            return 30 if HebrewDate.year_size(self.year) in (355, 385) else 29
         return 0
+
+    def is_leap_year(self) -> bool:
+        """Return: True if the year is a leap year."""
+        return self.year % 19 in (0, 3, 6, 8, 11, 14, 17)
 
     def get_next_month(self, month: Months, year: int) -> Months:
         """Return the next month."""
 
-        def is_leap(year: int) -> bool:
-            return year % 19 in (0, 3, 6, 8, 11, 14, 17)
-
-        if is_leap(year):
+        if HebrewDate(year).is_leap_year():
             if month == Months.SHVAT:
                 return Months.ADAR_I
             if month == Months.ADAR_I:

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime as dt
-from copy import deepcopy
 from dataclasses import dataclass
 from typing import Union
 
@@ -60,30 +59,20 @@ class HebrewDate(TranslatorMixin):
     def __add__(self, other: object) -> HebrewDate:
         if not isinstance(other, dt.timedelta):
             return NotImplemented
-        days = other.days  # Number of days to add
-        new = HebrewDate(self.year, self.month, self.day)
-        while days != 0:
-            days_left_in_month = new.get_month_days(Months(new.month)) - new.day
-            if abs(days) > days_left_in_month:
-                days -= days_left_in_month
-                new.day = 1
-                new.month = self.get_next_month(Months(new.month), new.year)
-                if new.month == Months.TISHREI:
-                    new.year += 1
-            else:
-                new.day += days
-                break
-
-        return new
+        new_gdate = self.to_gdate() + other
+        return HebrewDate.from_gdate(new_gdate)
 
     def __sub__(self, other: object) -> dt.timedelta:
         if not isinstance(other, HebrewDate):
             return NotImplemented
-        local_self = deepcopy(self)
-        local_other = deepcopy(other)
         if self.year == 0 or other.year == 0:
-            local_self.year = local_other.year = max(self.year, other.year)
-        days = self.to_jdn() - other.to_jdn()
+            adjusted_year = max(self.year, other.year)
+            local_self = HebrewDate(adjusted_year, self.month, self.day)
+            local_other = HebrewDate(adjusted_year, other.month, other.day)
+        else:
+            local_self = self
+            local_other = other
+        days = local_self.to_jdn() - local_other.to_jdn()
         return dt.timedelta(days=days)
 
     def to_jdn(self) -> int:

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Union
 
 import hdate.converters as conv
-from hdate.htables import Days, Months
+from hdate.htables import CHANGING_MONTHS, LONG_MONTHS, SHORT_MONTHS, Days, Months
 from hdate.translator import TranslatorMixin
 
 
@@ -239,31 +239,17 @@ class HebrewDate(TranslatorMixin):
 
     def days_in_month(self, month: Months) -> int:
         """Return the number of days in a month."""
-        if month in (
-            Months.TISHREI,
-            Months.SHVAT,
-            Months.ADAR_I,
-            Months.NISAN,
-            Months.SIVAN,
-            Months.AV,
-        ):
+        if month in LONG_MONTHS:
             return 30
-        if month in (
-            Months.TEVET,
-            Months.ADAR,
-            Months.ADAR_II,
-            Months.IYYAR,
-            Months.TAMMUZ,
-            Months.ELUL,
-        ):
+        if month in SHORT_MONTHS:
             return 29
-        if self.year == 0 and month in (Months.MARCHESHVAN, Months.KISLEV):
+        if self.year == 0 and month in CHANGING_MONTHS:
             # Special case for relative dates, return the maximum number of days
             return 30
         if month == Months.KISLEV:
-            return 29 if HebrewDate.year_size(self.year) in (353, 383) else 30
+            return 29 if self.short_kislev() else 30
         if month == Months.MARCHESHVAN:
-            return 30 if HebrewDate.year_size(self.year) in (355, 385) else 29
+            return 30 if self.long_cheshvan() else 29
         return 0
 
     def is_leap_year(self) -> bool:
@@ -286,3 +272,11 @@ class HebrewDate(TranslatorMixin):
     def dow(self) -> Days:
         """Return: day of the week."""
         return Days((self.to_jdn() + 1) % 7 + 1)
+
+    def short_kislev(self) -> bool:
+        """Return whether this year has a short Kislev or not."""
+        return self.year_size(self.year) in (353, 383)
+
+    def long_cheshvan(self) -> bool:
+        """Return whether this year has a long Cheshvan or not."""
+        return self.year_size(self.year) in (355, 385)

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -112,11 +112,6 @@ class HebrewDate(TranslatorMixin):
         return day + 1715118
 
     @staticmethod
-    def from_gdate(date: dt.date) -> HebrewDate:
-        """Return Hebrew date from Gregorian date."""
-        return HebrewDate.from_jdn(conv.gdate_to_jdn(date))
-
-    @staticmethod
     def from_jdn(jdn: int) -> HebrewDate:
         """Convert from the Julian day to the Hebrew day."""
         # calculate Gregorian date
@@ -168,6 +163,15 @@ class HebrewDate(TranslatorMixin):
             month = month + 1
 
         return HebrewDate(year, Months(month), day)
+
+    @staticmethod
+    def from_gdate(date: dt.date) -> HebrewDate:
+        """Return Hebrew date from Gregorian date."""
+        return HebrewDate.from_jdn(conv.gdate_to_jdn(date))
+
+    def to_gdate(self) -> dt.date:
+        """Return Gregorian date from Hebrew date."""
+        return conv.jdn_to_gdate(self.to_jdn())
 
     @staticmethod
     def _days_from_3744(hebrew_year: int) -> int:

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -1,10 +1,25 @@
 """Pure Hebrew date class."""
 
+from __future__ import annotations
+
+import datetime as dt
 from dataclasses import dataclass
 from typing import Union
 
+import hdate.converters as conv
 from hdate.htables import Months
 from hdate.translator import TranslatorMixin
+
+
+def get_chalakim(hours: int, parts: int) -> int:
+    """Return the number of total parts (chalakim)."""
+    return (hours * PARTS_IN_HOUR) + parts
+
+
+PARTS_IN_HOUR = 1080
+PARTS_IN_DAY = 24 * PARTS_IN_HOUR
+PARTS_IN_WEEK = 7 * PARTS_IN_DAY
+PARTS_IN_MONTH = PARTS_IN_DAY + get_chalakim(12, 793)  # Fix for regular month
 
 
 @dataclass
@@ -35,3 +50,220 @@ class HebrewDate(TranslatorMixin):
         if self.year == 0 or other.year == 0:
             return (self.month, self.day) < (other.month, other.day)
         return (self.year, self.month, self.day) < (other.year, other.month, other.day)
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, HebrewDate):
+            return NotImplemented
+        return self < other or self == other
+
+    def __add__(self, other: object) -> HebrewDate:
+        if not isinstance(other, dt.timedelta):
+            return NotImplemented
+        days = other.days  # Number of days to add
+        day, month, year = self.day, self.month, self.year
+        while days > 0:
+            days_left_in_month = self.get_month_days(Months(month), year) - day
+            if days_left_in_month > days:
+                day += days
+                break
+            days -= days_left_in_month
+            day = 1
+            month = self.get_next_month(Months(month), year)
+            if month == Months.TISHREI:
+                year += 1
+
+        return HebrewDate(year, month, day)
+
+    def __sub__(self, other: object) -> dt.timedelta:
+        if not isinstance(other, HebrewDate):
+            return NotImplemented
+        days = self.to_jdn() - other.to_jdn()
+        return dt.timedelta(days=days)
+
+    def to_jdn(self) -> int:
+        """
+        Compute Julian day from Hebrew day, month and year.
+
+        Return: julian day number
+        """
+        day = self.day
+        month = self.month.value if isinstance(self.month, Months) else self.month
+
+        if self.month == Months.ADAR_I:
+            month = 6
+        if self.month == Months.ADAR_II:
+            month = 6
+            day += 30
+
+        # Calculate days since 1,1,3744
+        day = HebrewDate._days_from_3744(self.year) + (59 * (month - 1) + 1) // 2 + day
+
+        # length of year
+        length_of_year = HebrewDate.year_size(self.year)
+        # Special cases for this year
+        if length_of_year % 10 > 4 and month > 2:  # long Heshvan
+            day += 1
+        if length_of_year % 10 < 4 and month > 3:  # short Kislev
+            day -= 1
+        if length_of_year > 365 and month > 6:  # leap year
+            day += 30
+
+        # adjust to julian
+        return day + 1715118
+
+    @staticmethod
+    def from_gdate(date: dt.date) -> HebrewDate:
+        """Return Hebrew date from Gregorian date."""
+        return HebrewDate.from_jdn(conv.gdate_to_jdn(date))
+
+    @staticmethod
+    def from_jdn(jdn: int) -> HebrewDate:
+        """Convert from the Julian day to the Hebrew day."""
+        # calculate Gregorian date
+        date = conv.jdn_to_gdate(jdn)
+
+        # Guess Hebrew year is Gregorian year + 3760
+        year = date.year + 3760
+
+        jdn_tishrey1 = HebrewDate(year, Months.TISHREI, 1).to_jdn()
+        jdn_tishrey1_next_year = HebrewDate(year + 1, Months.TISHREI, 1).to_jdn()
+
+        # Check if computed year was underestimated
+        if jdn_tishrey1_next_year <= jdn:
+            year = year + 1
+            jdn_tishrey1 = jdn_tishrey1_next_year
+            jdn_tishrey1_next_year = HebrewDate(year + 1, Months.TISHREI, 1).to_jdn()
+
+        size_of_year = HebrewDate.year_size(year)
+
+        # days into this year, first month 0..29
+        days = jdn - jdn_tishrey1
+
+        # last 8 months always have 236 days
+        if days >= (size_of_year - 236):  # in last 8 months
+            days = days - (size_of_year - 236)
+            month = days * 2 // 59
+            day = days - (month * 59 + 1) // 2 + 1
+
+            month = month + 4 + 1
+
+            # if leap
+            if size_of_year > 355 and month <= 6:
+                month = month + 8
+        else:  # in 4-5 first months
+            # Special cases for this year
+            if size_of_year % 10 > 4 and days == 59:  # long Heshvan (day 30)
+                month = 1
+                day = 30
+            elif size_of_year % 10 > 4 and days > 59:  # long Heshvan
+                month = (days - 1) * 2 // 59
+                day = days - (month * 59 + 1) // 2
+            elif size_of_year % 10 < 4 and days > 87:  # short kislev
+                month = (days + 1) * 2 // 59
+                day = days - (month * 59 + 1) // 2 + 2
+            else:  # regular months
+                month = days * 2 // 59
+                day = days - (month * 59 + 1) // 2 + 1
+
+            month = month + 1
+
+        return HebrewDate(year, Months(month), day)
+
+    @staticmethod
+    def _days_from_3744(hebrew_year: int) -> int:
+        """Return: Number of days since the molad of year 3744."""
+        # Start point for calculation is Molad new year 3744 (16BC)
+        years_from_3744 = hebrew_year - 3744
+        molad_3744 = get_chalakim(1 + 6, 779)  # Molad 3744 + 6 hours in parts
+
+        # Time in months
+
+        # Number of leap months
+        leap_months = (years_from_3744 * 7 + 1) // 19
+        leap_left = (years_from_3744 * 7 + 1) % 19  # Months left of leap cycle
+        months = years_from_3744 * 12 + leap_months  # Total Number of months
+
+        # Time in parts and days
+        # Molad This year + Molad 3744 - corrections
+        parts = months * PARTS_IN_MONTH + molad_3744
+        # 28 days in month + corrections
+        days = months * 28 + parts // PARTS_IN_DAY - 2
+
+        # Time left for round date in corrections
+        # 28 % 7 = 0 so only corrections counts
+        parts_left_in_week = parts % PARTS_IN_WEEK
+        parts_left_in_day = parts % PARTS_IN_DAY
+        week_day = parts_left_in_week // PARTS_IN_DAY
+
+        # Molad ד"ר ט"ג
+        molad_get_red = (
+            leap_left < 12
+            and week_day == 3
+            and parts_left_in_day >= get_chalakim(9 + 6, 204)
+        )
+
+        # Molad ט"פקת ו"טב
+        molad_betu_takpat = (
+            leap_left < 7
+            and week_day == 2
+            and parts_left_in_day >= get_chalakim(15 + 6, 589)
+        )
+
+        if molad_get_red or molad_betu_takpat:
+            days += 1
+            week_day += 1
+
+        # Lo Adu rosh
+        if week_day in (1, 4, 6):
+            days += 1
+
+        return days
+
+    @staticmethod
+    def year_size(hebrew_year: int) -> int:
+        """Return: total days in hebrew year."""
+        return HebrewDate._days_from_3744(hebrew_year + 1) - HebrewDate._days_from_3744(
+            hebrew_year
+        )
+
+    def get_month_days(self, month: Months, year: int) -> int:
+        """Return the number of days in a month."""
+        if month in (
+            Months.TISHREI,
+            Months.SHVAT,
+            Months.ADAR_I,
+            Months.NISAN,
+            Months.SIVAN,
+            Months.AV,
+        ):
+            return 30
+        if month in (
+            Months.TEVET,
+            Months.ADAR,
+            Months.ADAR_II,
+            Months.IYYAR,
+            Months.TAMMUZ,
+            Months.ELUL,
+        ):
+            return 29
+        if month == Months.KISLEV:
+            return 29 if HebrewDate.year_size(year) in (353, 383) else 30
+        if month == Months.MARCHESHVAN:
+            return 30 if HebrewDate.year_size(year) in (355, 385) else 29
+        return 0
+
+    def get_next_month(self, month: Months, year: int) -> Months:
+        """Return the next month."""
+
+        def is_leap(year: int) -> bool:
+            return year % 19 in (0, 3, 6, 8, 11, 14, 17)
+
+        if is_leap(year):
+            if month == Months.SHVAT:
+                return Months.ADAR_I
+            if month == Months.ADAR_I:
+                return Months.ADAR_II
+            if month == Months.ADAR_II:
+                return Months.NISAN
+        next_month = month + 1 if month < Months.ELUL else Months.TISHREI
+        return Months(next_month)

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Union
 
 import hdate.converters as conv
-from hdate.htables import Months
+from hdate.htables import Days, Months
 from hdate.translator import TranslatorMixin
 
 
@@ -271,3 +271,7 @@ class HebrewDate(TranslatorMixin):
                 return Months.NISAN
         next_month = month + 1 if month < Months.ELUL else Months.TISHREI
         return Months(next_month)
+
+    def dow(self) -> Days:
+        """Return: day of the week."""
+        return Days((self.to_jdn() + 1) % 7 + 1)

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -627,7 +627,7 @@ HOLIDAYS = (
         [
             year_is_after(5708),
             year_is_before(5764),
-            move_if_not_on_dow(4, 3, Days.THURSDAY, Days.TUESDAY)  # type: ignore
+            move_if_not_on_dow(4, 3, Days.THURSDAY, Days.WEDNESDAY)  # type: ignore
             or move_if_not_on_dow(4, 2, Days.FRIDAY, Days.WEDNESDAY),
         ],
     ),

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -423,7 +423,7 @@ def year_is_before(year: int) -> Callable[[HebrewDateT], bool]:
 
 
 def move_if_not_on_dow(
-    original: int, replacement: int, dow_not_orig: int, dow_replacement: int
+    original: int, replacement: int, dow_not_orig: Days, dow_replacement: Days
 ) -> Callable[[HebrewDateT], bool]:
     """
     Return a lambda function.
@@ -447,7 +447,7 @@ def correct_adar() -> Callable[[HebrewDateT], Union[bool, Callable[[], bool]]]:
     return lambda x: (
         (x.month not in [Months.ADAR, Months.ADAR_I, Months.ADAR_II])
         or (x.month == Months.ADAR and not x.is_leap_year())
-        or (x.month in [Months.ADAR_I, Months.ADAR_II] and x.is_leap_year())
+        or (x.month in (Months.ADAR_I, Months.ADAR_II) and x.is_leap_year())
     )
 
 
@@ -495,7 +495,7 @@ HOLIDAYS = (
         "tzom_gedaliah",
         ((3, 4), Months.TISHREI),
         "",
-        [move_if_not_on_dow(3, 4, 5, 6)],
+        [move_if_not_on_dow(3, 4, Days.SATURDAY, Days.SUNDAY)],
     ),
     Holiday(HolidayTypes.EREV_YOM_TOV, "erev_yom_kippur", (9, Months.TISHREI), "", []),
     Holiday(HolidayTypes.YOM_TOV, "yom_kippur", (10, Months.TISHREI), "", []),
@@ -536,7 +536,7 @@ HOLIDAYS = (
         "taanit_esther",
         ((11, 13), (Months.ADAR, Months.ADAR_II)),
         "",
-        [move_if_not_on_dow(13, 11, 5, 3), correct_adar()],
+        [move_if_not_on_dow(13, 11, Days.SATURDAY, Days.THURSDAY), correct_adar()],
     ),
     Holiday(
         HolidayTypes.MELACHA_PERMITTED_HOLIDAY,
@@ -574,8 +574,8 @@ HOLIDAYS = (
         [
             year_is_after(5708),
             year_is_before(5764),
-            move_if_not_on_dow(5, 4, 4, 3)  # type: ignore
-            or move_if_not_on_dow(5, 3, 5, 3),
+            move_if_not_on_dow(5, 4, Days.FRIDAY, Days.THURSDAY)  # type: ignore
+            or move_if_not_on_dow(5, 3, Days.SATURDAY, Days.THURSDAY),
         ],
     ),
     Holiday(
@@ -585,9 +585,9 @@ HOLIDAYS = (
         "",
         [
             year_is_after(5763),
-            move_if_not_on_dow(5, 4, 4, 3)  # type: ignore
-            or move_if_not_on_dow(5, 3, 5, 3)
-            or move_if_not_on_dow(5, 6, 0, 1),
+            move_if_not_on_dow(5, 4, Days.FRIDAY, Days.THURSDAY)  # type: ignore
+            or move_if_not_on_dow(5, 3, Days.SATURDAY, Days.THURSDAY)
+            or move_if_not_on_dow(5, 6, Days.MONDAY, Days.TUESDAY),
         ],
     ),
     Holiday(HolidayTypes.MINOR_HOLIDAY, "lag_bomer", (18, Months.IYYAR), "", []),
@@ -598,14 +598,14 @@ HOLIDAYS = (
         "tzom_tammuz",
         ((17, 18), Months.TAMMUZ),
         "",
-        [move_if_not_on_dow(17, 18, 5, 6)],
+        [move_if_not_on_dow(17, 18, Days.SATURDAY, Days.SUNDAY)],
     ),
     Holiday(
         HolidayTypes.FAST_DAY,
         "tisha_bav",
         ((9, 10), Months.AV),
         "",
-        [move_if_not_on_dow(9, 10, 5, 6)],
+        [move_if_not_on_dow(9, 10, Days.SATURDAY, Days.SUNDAY)],
     ),
     Holiday(HolidayTypes.MINOR_HOLIDAY, "tu_bav", (15, Months.AV), "", []),
     Holiday(
@@ -614,8 +614,8 @@ HOLIDAYS = (
         ((26, 27, 28), Months.NISAN),
         "",
         [
-            move_if_not_on_dow(27, 28, 6, 0)  # type: ignore
-            or move_if_not_on_dow(27, 26, 4, 3),
+            move_if_not_on_dow(27, 28, Days.SUNDAY, Days.MONDAY)  # type: ignore
+            or move_if_not_on_dow(27, 26, Days.FRIDAY, Days.THURSDAY),
             year_is_after(5718),
         ],
     ),
@@ -627,8 +627,8 @@ HOLIDAYS = (
         [
             year_is_after(5708),
             year_is_before(5764),
-            move_if_not_on_dow(4, 3, 3, 2)  # type: ignore
-            or move_if_not_on_dow(4, 2, 4, 2),
+            move_if_not_on_dow(4, 3, Days.THURSDAY, Days.TUESDAY)  # type: ignore
+            or move_if_not_on_dow(4, 2, Days.FRIDAY, Days.WEDNESDAY),
         ],
     ),
     Holiday(
@@ -638,9 +638,9 @@ HOLIDAYS = (
         "",
         [
             year_is_after(5763),
-            move_if_not_on_dow(4, 3, 3, 2)  # type: ignore
-            or move_if_not_on_dow(4, 2, 4, 2)
-            or move_if_not_on_dow(4, 5, 6, 0),
+            move_if_not_on_dow(4, 3, Days.THURSDAY, Days.WEDNESDAY)  # type: ignore
+            or move_if_not_on_dow(4, 2, Days.FRIDAY, Days.WEDNESDAY)
+            or move_if_not_on_dow(4, 5, Days.SUNDAY, Days.MONDAY),
         ],
     ),
     Holiday(
@@ -674,7 +674,7 @@ HOLIDAYS = (
         "rabin_memorial_day",
         ((11, 12), Months.MARCHESHVAN),
         "ISRAEL",
-        [move_if_not_on_dow(12, 11, 4, 3), year_is_after(5757)],
+        [move_if_not_on_dow(12, 11, Days.FRIDAY, Days.THURSDAY), year_is_after(5757)],
     ),
     Holiday(
         HolidayTypes.MEMORIAL_DAY,

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -1,6 +1,6 @@
 """Constant lookup tables for hdate modules."""
 
-import datetime
+import datetime as dt
 from dataclasses import dataclass
 from enum import Enum, IntEnum, auto
 from typing import Callable, TypeVar, Union
@@ -722,7 +722,7 @@ def get_all_holidays(language: str) -> list[str]:
 # The first few cycles were only 2702 blatt. After that it became 2711. Even with
 # that, the math doesn't play nicely with the dates before the 11th cycle :(
 # From cycle 11 onwards, it was simple and sequential
-DAF_YOMI_CYCLE_11_START = datetime.date(1997, 9, 29)
+DAF_YOMI_CYCLE_11_START = dt.date(1997, 9, 29)
 
 
 @dataclass

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:767d38e31785d3439d1850bbb1e5401216f541aab8e6a61792c40f47abb63dc2"
+content_hash = "sha256:1f5b1ffa4fcaea060ebe81a1abf24e03ee1a64da75d0d4ba43b17b4404db1c7e"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -48,6 +48,17 @@ dependencies = [
 files = [
     {file = "astroid-3.3.5-py3-none-any.whl", hash = "sha256:a9d1c946ada25098d790e079ba2a1b112157278f3fb7e718ae6a9252f5835dc8"},
     {file = "astroid-3.3.5.tar.gz", hash = "sha256:5cfc40ae9f68311075d27ef68a4841bdc5cc7f6cf86671b49f00607d30188e2d"},
+]
+
+[[package]]
+name = "attrs"
+version = "24.3.0"
+requires_python = ">=3.8"
+summary = "Classes Without Boilerplate"
+groups = ["dev"]
+files = [
+    {file = "attrs-24.3.0-py3-none-any.whl", hash = "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"},
+    {file = "attrs-24.3.0.tar.gz", hash = "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff"},
 ]
 
 [[package]]
@@ -467,6 +478,22 @@ groups = ["dev"]
 files = [
     {file = "gprof2dot-2024.6.6-py2.py3-none-any.whl", hash = "sha256:45b14ad7ce64e299c8f526881007b9eb2c6b75505d5613e96e66ee4d5ab33696"},
     {file = "gprof2dot-2024.6.6.tar.gz", hash = "sha256:fa1420c60025a9eb7734f65225b4da02a10fc6dd741b37fa129bc6b41951e5ab"},
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.123.2"
+requires_python = ">=3.9"
+summary = "A library for property-based testing"
+groups = ["dev"]
+dependencies = [
+    "attrs>=22.2.0",
+    "exceptiongroup>=1.0.0; python_version < \"3.11\"",
+    "sortedcontainers<3.0.0,>=2.1.0",
+]
+files = [
+    {file = "hypothesis-6.123.2-py3-none-any.whl", hash = "sha256:0a8bf07753f1436f1b8697a13ea955f3fef3ef7b477c2972869b1d142bcdb30e"},
+    {file = "hypothesis-6.123.2.tar.gz", hash = "sha256:02c25552783764146b191c69eef69d8375827b58a75074055705ab8fdbc95fc5"},
 ]
 
 [[package]]
@@ -992,6 +1019,16 @@ groups = ["dev"]
 files = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+summary = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+groups = ["dev"]
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "flake8>=7.1.1",
     "mypy>=1.13.0",
     "pytest-profiling>=1.8.1",
+    "hypothesis>=6.123.2",
 ]
 test = [
     "pytest>=8.3.3",

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -31,14 +31,14 @@ class TestConverters:
             for month in months:
                 for day in range(1, days_in_month + 1):
                     date = HebrewDate(year, month, day)
-                    assert conv.jdn_to_hdate(conv.hdate_to_jdn(date)) == date
+                    assert HebrewDate.from_jdn(date.to_jdn()) == date
 
     @pytest.mark.parametrize("year", YEARS_PSHUTA)
     def test_hdate_to_hdate_pshuta_adar(self, year: int) -> None:
         """Transform Hebrew date to Hebrew date (in Adar)."""
         for day in range(1, 29 + 1):
             date = HebrewDate(year, Months.ADAR, day)
-            assert conv.jdn_to_hdate(conv.hdate_to_jdn(date)) == date
+            assert HebrewDate.from_jdn(date.to_jdn()) == date
 
     @pytest.mark.parametrize("year", YEARS_PSHUTA)
     def test_hdate_to_hdate_pshuta_heshvan(self, year: int) -> None:
@@ -46,7 +46,7 @@ class TestConverters:
         days_in_month = 29 if not year == 5756 else 30
         for day in range(1, days_in_month + 1):
             date = HebrewDate(year, Months.MARCHESHVAN, day)
-            assert conv.jdn_to_hdate(conv.hdate_to_jdn(date)) == date
+            assert HebrewDate.from_jdn(date.to_jdn()) == date
 
     @pytest.mark.parametrize("year", YEARS_PSHUTA)
     def test_hdate_to_hdate_pshuta_kislev(self, year: int) -> None:
@@ -54,7 +54,7 @@ class TestConverters:
         days_in_month = 30 if not year == 5753 else 29
         for day in range(1, days_in_month + 1):
             date = HebrewDate(year, Months.KISLEV, day)
-            assert conv.jdn_to_hdate(conv.hdate_to_jdn(date)) == date
+            assert HebrewDate.from_jdn(date.to_jdn()) == date
 
     @pytest.mark.parametrize("year", YEARS_MEUBERET)
     def test_hdate_to_hdate_meuberet_simple(self, year: int) -> None:
@@ -63,17 +63,17 @@ class TestConverters:
             for month in months:
                 for day in range(1, days_in_month + 1):
                     date = HebrewDate(year, month, day)
-                    assert conv.jdn_to_hdate(conv.hdate_to_jdn(date)) == date
+                    assert HebrewDate.from_jdn(date.to_jdn()) == date
 
     @pytest.mark.parametrize("year", YEARS_MEUBERET)
     def test_hdate_to_hdate_meuberet_adar(self, year: int) -> None:
         """Transform Hebrew date to hebrew date (two Adars - test Adar)."""
         for day in range(1, 30 + 1):
             date = HebrewDate(year, Months.ADAR_I, day)
-            assert conv.jdn_to_hdate(conv.hdate_to_jdn(date)) == date
+            assert HebrewDate.from_jdn(date.to_jdn()) == date
         for day in range(1, 29 + 1):
             date = HebrewDate(year, Months.ADAR_II, day)
-            assert conv.jdn_to_hdate(conv.hdate_to_jdn(date)) == date
+            assert HebrewDate.from_jdn(date.to_jdn()) == date
 
     @pytest.mark.parametrize("year", YEARS_MEUBERET)
     def test_hdate_to_hdate_meuberet_heshvan(self, year: int) -> None:
@@ -81,7 +81,7 @@ class TestConverters:
         days_in_month = 29 if not year == 5760 else 30
         for day in range(1, days_in_month + 1):
             date = HebrewDate(year, Months.MARCHESHVAN, day)
-            assert conv.jdn_to_hdate(conv.hdate_to_jdn(date)) == date
+            assert HebrewDate.from_jdn(date.to_jdn()) == date
 
     @pytest.mark.parametrize("year", YEARS_MEUBERET)
     def test_hdate_to_hdate_meuberet_kislev(self, year: int) -> None:
@@ -89,4 +89,4 @@ class TestConverters:
         days_in_month = 30 if not year == 5749 else 29
         for day in range(1, days_in_month + 1):
             date = HebrewDate(year, Months.KISLEV, day)
-            assert conv.jdn_to_hdate(conv.hdate_to_jdn(date)) == date
+            assert HebrewDate.from_jdn(date.to_jdn()) == date

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -97,13 +97,11 @@ class TestHDate:
         print(f"Run number: {execution_number}")
         assert rand_hdate.year_size() == HebrewDate.year_size(rand_hdate.hdate.year)
 
-    def test_rosh_hashana_day_of_week(self, rand_hdate: HDate) -> None:
+    def test_rosh_hashana_day_of_week(self) -> None:
         """Check that Rosh Hashana's DOW matches the given dates"""
         for year, info in list(HEBREW_YEARS_INFO.items()):
-            rand_hdate.hdate = HebrewDate(
-                year, rand_hdate.hdate.month, rand_hdate.hdate.day
-            )
-            assert rand_hdate.rosh_hashana_dow() == info[0]
+            rosh_hashana = HebrewDate(year)
+            assert rosh_hashana.dow() == info[0]
 
     def test_pesach_day_of_week(self, rand_hdate: HDate) -> None:
         """ "Check tha Pesach DOW matches the given dates."""

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -1,6 +1,6 @@
 """Test HDate objects."""
 
-import datetime
+import datetime as dt
 import random
 from collections import defaultdict
 from typing import Union
@@ -133,17 +133,15 @@ class TestHDate:
         hebrew_date: tuple[int, int, int],
     ) -> None:
         """Check the date of the upcoming Shabbat."""
-        date = HDate(gdate=datetime.date(*current_date))
+        date = HDate(gdate=dt.date(*current_date))
         assert date.hdate == HebrewDate(*hebrew_date)
         next_shabbat = date.upcoming_shabbat
-        assert next_shabbat.gdate == datetime.date(*shabbat_date)
+        assert next_shabbat.gdate == dt.date(*shabbat_date)
 
     def test_prev_and_next_day(self, rand_hdate: HDate) -> None:
         """Check the previous and next day attributes."""
-        assert (rand_hdate.previous_day.gdate - rand_hdate.gdate) == datetime.timedelta(
-            -1
-        )
-        assert (rand_hdate.next_day.gdate - rand_hdate.gdate) == datetime.timedelta(1)
+        assert (rand_hdate.previous_day.gdate - rand_hdate.gdate) == dt.timedelta(-1)
+        assert (rand_hdate.next_day.gdate - rand_hdate.gdate) == dt.timedelta(1)
 
 
 class TestSpecialDays:
@@ -290,13 +288,13 @@ class TestSpecialDays:
         """Testing the value of next yom tov."""
         print(f"Testing holiday {holiday_name}")
         if where in ("BOTH", "DIASPORA"):
-            hdate = HDate(gdate=datetime.date(*current_date), diaspora=True)
+            hdate = HDate(gdate=dt.date(*current_date), diaspora=True)
             next_yom_tov = hdate.upcoming_yom_tov
-            assert next_yom_tov.gdate == datetime.date(*holiday_date)
+            assert next_yom_tov.gdate == dt.date(*holiday_date)
         if where in ("BOTH", "ISRAEL"):
-            hdate = HDate(gdate=datetime.date(*current_date), diaspora=False)
+            hdate = HDate(gdate=dt.date(*current_date), diaspora=False)
             next_yom_tov = hdate.upcoming_yom_tov
-            assert next_yom_tov.gdate == datetime.date(*holiday_date)
+            assert next_yom_tov.gdate == dt.date(*holiday_date)
 
     UPCOMING_SHABBAT_OR_YOM_TOV = [
         ((2018, 9, 8), True, {"start": (2018, 9, 8), "end": (2018, 9, 8)}),
@@ -327,13 +325,11 @@ class TestSpecialDays:
         dates: dict[str, tuple[int, int, int]],
     ) -> None:
         """Test getting the next shabbat or Yom Tov works."""
-        date = HDate(gdate=datetime.date(*current_date), diaspora=diaspora)
-        assert date.upcoming_shabbat_or_yom_tov.first_day.gdate == datetime.date(
+        date = HDate(gdate=dt.date(*current_date), diaspora=diaspora)
+        assert date.upcoming_shabbat_or_yom_tov.first_day.gdate == dt.date(
             *dates["start"]
         )
-        assert date.upcoming_shabbat_or_yom_tov.last_day.gdate == datetime.date(
-            *dates["end"]
-        )
+        assert date.upcoming_shabbat_or_yom_tov.last_day.gdate == dt.date(*dates["end"])
 
     @pytest.mark.parametrize("date, holiday", NON_MOVING_HOLIDAYS)
     def test_get_holidays_non_moving(
@@ -456,7 +452,7 @@ class TestSpecialDays:
 
     def test_hanukah_5785(self) -> None:
         """December 31, 2024 is Hanuka."""
-        mydate = HDate(gdate=datetime.date(2024, 12, 31))
+        mydate = HDate(gdate=dt.date(2024, 12, 31))
         assert "chanukah" in mydate.holiday_name
         assert "rosh_chodesh" in mydate.holiday_name
 
@@ -519,16 +515,16 @@ class TestSpecialDays:
     def test_daf_yomi(self) -> None:
         """Test value of Daf Yomi."""
         # Random test date
-        myhdate = HDate(gdate=datetime.date(2014, 4, 28), language="english")
+        myhdate = HDate(gdate=dt.date(2014, 4, 28), language="english")
         assert myhdate.daf_yomi == "Beitzah 29"
         # Beginning/end of cycle:
-        myhdate = HDate(gdate=datetime.date(2020, 1, 4), language="english")
+        myhdate = HDate(gdate=dt.date(2020, 1, 4), language="english")
         assert myhdate.daf_yomi == "Niddah 73"
-        myhdate = HDate(gdate=datetime.date(2020, 1, 5), language="english")
+        myhdate = HDate(gdate=dt.date(2020, 1, 5), language="english")
         assert myhdate.daf_yomi == "Berachos 2"
-        myhdate = HDate(gdate=datetime.date(2020, 3, 7), language="hebrew")
+        myhdate = HDate(gdate=dt.date(2020, 3, 7), language="hebrew")
         assert myhdate.daf_yomi == "ברכות סד"
-        myhdate = HDate(gdate=datetime.date(2020, 3, 8), language="hebrew")
+        myhdate = HDate(gdate=dt.date(2020, 3, 8), language="hebrew")
         assert myhdate.daf_yomi == "שבת ב"
 
 
@@ -857,14 +853,14 @@ class TestHDateReading:
         mydate.hdate = HebrewDate(year, 1, 1)
 
         # Get next Saturday
-        tdelta = datetime.timedelta((12 - mydate.gdate.weekday()) % 7)
+        tdelta = dt.timedelta((12 - mydate.gdate.weekday()) % 7)
         mydate.gdate += tdelta
 
         shabatot = [item for subl in parshiyot for item in subl]
         for shabbat in shabatot:
             print("Testing: ", mydate)
             assert mydate.get_reading() == shabbat
-            mydate.gdate += datetime.timedelta(days=7)
+            mydate.gdate += dt.timedelta(days=7)
         mydate.hdate = HebrewDate(year, 1, 22)
         # VeZot Habracha in Israel always falls on 22 of Tishri
         assert mydate.get_reading() == 54
@@ -876,14 +872,14 @@ class TestHDateReading:
         mydate.hdate = HebrewDate(year, 1, 1)
 
         # Get next Saturday
-        tdelta = datetime.timedelta((12 - mydate.gdate.weekday()) % 7)
+        tdelta = dt.timedelta((12 - mydate.gdate.weekday()) % 7)
         mydate.gdate += tdelta
 
         shabatot = [item for subl in parshiyot for item in subl]
         for shabbat in shabatot:
             print("Testing: ", mydate)
             assert mydate.get_reading() == shabbat
-            mydate.gdate += datetime.timedelta(days=7)
+            mydate.gdate += dt.timedelta(days=7)
         mydate.hdate = HebrewDate(year, 1, 23)
         # VeZot Habracha in Israel always falls on 22 of Tishri
         assert mydate.get_reading() == 54
@@ -893,7 +889,7 @@ class TestHDateReading:
         """A property: Nitzavim alway falls before rosh hashana."""
         mydate = HDate(language="english", diaspora=False)
         mydate.hdate = HebrewDate(year, Months.TISHREI, 1)
-        tdelta = datetime.timedelta((12 - mydate.gdate.weekday()) % 7 - 7)
+        tdelta = dt.timedelta((12 - mydate.gdate.weekday()) % 7 - 7)
         # Go back to the previous shabbat
         mydate.gdate += tdelta
         print("Testing date: {mydate} which is {tdelta} days before Rosh Hashana")
@@ -904,7 +900,7 @@ class TestHDateReading:
         """A property: Vayelech or Haazinu always falls after rosh hashana."""
         mydate = HDate(language="english", diaspora=True)
         mydate.hdate = HebrewDate(year, Months.TISHREI, 1)
-        tdelta = datetime.timedelta((12 - mydate.gdate.weekday()) % 7)
+        tdelta = dt.timedelta((12 - mydate.gdate.weekday()) % 7)
         # Go to the next shabbat (unless shabbat falls on Rosh Hashana)
         mydate.gdate += tdelta
         print(f"Testing date: {mydate} which is {tdelta} days after Rosh Hashana")

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -7,7 +7,6 @@ from typing import Union
 
 import pytest
 
-import hdate.converters as conv
 from hdate import HDate, HebrewDate
 from hdate.htables import Months
 
@@ -88,7 +87,7 @@ class TestHDate:
     def test_conv_get_size_of_hebrew_year(self) -> None:
         """Check that the size of year returned is correct."""
         for year, info in list(HEBREW_YEARS_INFO.items()):
-            assert conv.get_size_of_hebrew_year(year) == info[1]
+            assert HebrewDate.year_size(year) == info[1]
 
     @pytest.mark.parametrize("execution_number", list(range(10)))
     def test_hdate_get_size_of_hebrew_years(
@@ -96,9 +95,7 @@ class TestHDate:
     ) -> None:
         """Check that the year_size property returns the correct value."""
         print(f"Run number: {execution_number}")
-        assert rand_hdate.year_size() == conv.get_size_of_hebrew_year(
-            rand_hdate.hdate.year
-        )
+        assert rand_hdate.year_size() == HebrewDate.year_size(rand_hdate.hdate.year)
 
     def test_rosh_hashana_day_of_week(self, rand_hdate: HDate) -> None:
         """Check that Rosh Hashana's DOW matches the given dates"""
@@ -450,7 +447,7 @@ class TestSpecialDays:
     def test_get_holiday_hanuka_3rd_tevet(self) -> None:
         """Test Chanuka falling on 3rd of Tevet."""
         year = random.randint(5000, 6000)
-        year_size = conv.get_size_of_hebrew_year(year)
+        year_size = HebrewDate.year_size(year)
         myhdate = HDate(heb_date=HebrewDate(year, 4, 3))
         print(year_size)
         if year_size in [353, 383]:
@@ -469,7 +466,7 @@ class TestSpecialDays:
     def test_get_holiday_adar(self, possible_days: list[int], holiday: str) -> None:
         """Test holidays for Adar I/Adar II."""
         year = random.randint(5000, 6000)
-        year_size = conv.get_size_of_hebrew_year(year)
+        year_size = HebrewDate.year_size(year)
         month = 6 if year_size < 360 else 14
         myhdate = HDate()
 

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -151,13 +151,13 @@ class TestSpecialDays:
 
     def test_is_leap_year(self) -> None:
         """Test that is_leap_year() working as expected for leap year."""
-        leap_date = HDate(heb_date=HebrewDate(5784, 1, 1))
-        assert leap_date.is_leap_year
+        leap_date = HebrewDate(5784, 1, 1)
+        assert leap_date.is_leap_year()
 
     def test_is_not_leap_year(self) -> None:
         """Test that is_leap_year() working as expected for non-leap year."""
-        leap_date = HDate(heb_date=HebrewDate(5783, 1, 1))
-        assert not leap_date.is_leap_year
+        leap_date = HebrewDate(5783, 1, 1)
+        assert not leap_date.is_leap_year()
 
     # Test against both a leap year and non-leap year
     @pytest.mark.parametrize(("year"), ((5783, 5784)))

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -167,7 +167,7 @@ class TestSpecialDays:
 
         expected_holiday_map = defaultdict(list)
         for entry, date in cur_date.get_holidays_for_year():
-            expected_holiday_map[date.gdate].append(entry.name)
+            expected_holiday_map[date.to_gdate()].append(entry.name)
 
         while cur_date.hdate.year == year:
             actual_holiday = cur_date.holiday_name
@@ -183,13 +183,13 @@ class TestSpecialDays:
         """Test that get_holidays_for_year() returns consistent months."""
         base_date = HDate(heb_date=HebrewDate(5783, 1, 1))
         for _, date in base_date.get_holidays_for_year():
-            assert date.hdate.month not in [Months.ADAR_I, Months.ADAR_II]
+            assert date.month not in (Months.ADAR_I, Months.ADAR_II)
 
     def test_get_holidays_for_year_leap_year(self) -> None:
         """Test that get_holidays_for_year() returns consistent months."""
         base_date = HDate(heb_date=HebrewDate(5784, 1, 1))
         for _, date in base_date.get_holidays_for_year():
-            assert date.hdate.month != Months.ADAR
+            assert date.month != Months.ADAR
 
     NON_MOVING_HOLIDAYS = [
         ((1, 1), "rosh_hashana_i"),
@@ -345,7 +345,7 @@ class TestSpecialDays:
         """Test holidays that have a fixed hebrew date."""
         rand_hdate.hdate = HebrewDate(rand_hdate.hdate.year, date[1], date[0])
         if isinstance(holiday, list):
-            assert rand_hdate.holiday_name in holiday
+            assert set(rand_hdate.holiday_name) == set(holiday)
         else:
             assert rand_hdate.holiday_name == holiday
         assert rand_hdate.is_holiday
@@ -464,12 +464,14 @@ class TestSpecialDays:
     def test_get_holiday_adar(self, possible_days: list[int], holiday: str) -> None:
         """Test holidays for Adar I/Adar II."""
         year = random.randint(5000, 6000)
-        year_size = HebrewDate.year_size(year)
-        month = 6 if year_size < 360 else 14
-        myhdate = HDate()
+        date = HebrewDate(year)
+        date.month = Months.ADAR_II if date.is_leap_year() else Months.ADAR
+
+        print(f"Testing {holiday} for {date!r}")
 
         for day in possible_days:
-            myhdate.hdate = HebrewDate(year, month, day)
+            date.day = day
+            myhdate = HDate(heb_date=date)
             if day == 13 and myhdate.dow == 7 and holiday == "taanit_esther":
                 assert myhdate.holiday_name == ""
                 assert myhdate.is_holiday is False

--- a/tests/test_hdate_api.py
+++ b/tests/test_hdate_api.py
@@ -3,8 +3,8 @@ These tests are based on the API calls made to hdate by homeassistant (and
 maybe other apps in the future).
 """
 
+import datetime as dt
 import sys
-from datetime import date, datetime, tzinfo
 from typing import cast
 
 from _pytest.capture import CaptureFixture
@@ -20,7 +20,7 @@ class TestHDateAPI:
     def test_readme_example_english(self, capsys: CaptureFixture[str]) -> None:
         """Test the README example in English."""
 
-        test_date = date(2016, 4, 18)
+        test_date = dt.date(2016, 4, 18)
         hdate = HDate(test_date, language="english")
         print(hdate)
         captured = capsys.readouterr()
@@ -28,7 +28,7 @@ class TestHDateAPI:
 
     def test_readme_example_hebrew(self, capsys: CaptureFixture[str]) -> None:
         """Test the README example in Hebrew."""
-        test_date = date(2016, 4, 26)
+        test_date = dt.date(2016, 4, 26)
         hdate = HDate(test_date, language="hebrew")
         print(hdate)
         captured = capsys.readouterr()
@@ -36,43 +36,43 @@ class TestHDateAPI:
 
     def test_get_hebrew_date(self) -> None:
         """Print the hebrew date."""
-        test_date = datetime(2018, 11, 2)
+        test_date = dt.datetime(2018, 11, 2)
         assert HDate(test_date).hebrew_date == 'כ"ד מרחשוון ה\' תשע"ט'
         assert HDate(test_date, language="english").hebrew_date == "24 Marcheshvan 5779"
 
     def test_get_hebrew_date_multilanguage(self) -> None:
         """Print the hebrew date."""
-        test_date = datetime(2018, 11, 2)
+        test_date = dt.datetime(2018, 11, 2)
         assert HDate(test_date).hebrew_date == 'כ"ד מרחשוון ה\' תשע"ט'
         assert HDate(test_date, language="french").hebrew_date == "24 Heshvan 5779"
 
     def test_get_upcoming_parasha(self) -> None:
         """Check that the upcoming parasha is correct."""
-        test_date = datetime(2018, 11, 2)
+        test_date = dt.datetime(2018, 11, 2)
         assert HDate(test_date).parasha == "חיי שרה"
         assert HDate(test_date, language="english").parasha == "Chayei Sara"
 
     def test_get_upcoming_parasha_vezot_habracha(self) -> None:
         """Check that the upcoming parasha is correct for vezot habracha."""
-        test_date = datetime(2018, 9, 30)
+        test_date = dt.datetime(2018, 9, 30)
         assert HDate(test_date).parasha == "וזאת הברכה"
         assert HDate(test_date, language="english").parasha == "Vezot Habracha"
 
     def test_get_upcoming_parasha_vezot_habracha_french(self) -> None:
         """Check that the upcoming parasha is correct for vezot habracha in french."""
-        test_date = datetime(2018, 9, 30)
+        test_date = dt.datetime(2018, 9, 30)
         assert HDate(test_date).parasha == "וזאת הברכה"
         assert HDate(test_date, language="french").parasha == "Vezot Haberakha"
 
     def test_get_holiday_description(self) -> None:
         """Check that the holiday description is correct."""
-        test_date = datetime(2018, 12, 3)
+        test_date = dt.datetime(2018, 12, 3)
         assert HDate(test_date).holiday_description == "חנוכה"
         assert HDate(test_date, language="english").holiday_description == "Chanukah"
 
     def test_get_holiday_description_multi_language(self) -> None:
         """Check that the holiday description is correct in french."""
-        test_date = datetime(2018, 12, 3)
+        test_date = dt.datetime(2018, 12, 3)
         assert HDate(test_date).holiday_description == "חנוכה"
         assert HDate(test_date, language="french").holiday_description == "Hanoukka"
 
@@ -83,7 +83,7 @@ class TestZmanimAPI:
     def test_readme_example_hebrew(self, capsys: CaptureFixture[str]) -> None:
         """Test for hebrew."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2016, 4, 18), location=coord)
+        zman = Zmanim(date=dt.date(2016, 4, 18), location=coord)
         print(zman)
         captured = capsys.readouterr()
         if not _ASTRAL:
@@ -112,7 +112,7 @@ class TestZmanimAPI:
     def test_readme_example_english(self, capsys: CaptureFixture[str]) -> None:
         """Test for english."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2016, 4, 18), location=coord, language="english")
+        zman = Zmanim(date=dt.date(2016, 4, 18), location=coord, language="english")
         print(zman)
         captured = capsys.readouterr()
         if not _ASTRAL:
@@ -141,72 +141,72 @@ class TestZmanimAPI:
     def test_issur_melacha_weekday(self) -> None:
         """Test for issur melacha on a weekday."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2018, 11, 12), location=coord)
-        assert not zman.issur_melacha_in_effect(datetime(2018, 11, 12, 1, 2))
+        zman = Zmanim(date=dt.date(2018, 11, 12), location=coord)
+        assert not zman.issur_melacha_in_effect(dt.datetime(2018, 11, 12, 1, 2))
 
     def test_issur_melacha_shabbat_morning(self) -> None:
         """Test for issur melacha on shabbat morning."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2018, 11, 10), location=coord)
-        assert zman.issur_melacha_in_effect(datetime(2018, 11, 10, 9))
+        zman = Zmanim(date=dt.date(2018, 11, 10), location=coord)
+        assert zman.issur_melacha_in_effect(dt.datetime(2018, 11, 10, 9))
 
     def test_issur_melacha_friday_morning(self) -> None:
         """Test for issur melacha on friday morning."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2018, 11, 9), location=coord)
-        assert not zman.issur_melacha_in_effect(datetime(2018, 11, 9, 9, 45))
+        zman = Zmanim(date=dt.date(2018, 11, 9), location=coord)
+        assert not zman.issur_melacha_in_effect(dt.datetime(2018, 11, 9, 9, 45))
 
     def test_issur_melacha_friday_evening(self) -> None:
         """Test for issur melacha on friday evening."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2018, 11, 9), location=coord)
-        assert zman.issur_melacha_in_effect(datetime(2018, 11, 9, 16, 45))
+        zman = Zmanim(date=dt.date(2018, 11, 9), location=coord)
+        assert zman.issur_melacha_in_effect(dt.datetime(2018, 11, 9, 16, 45))
 
     def test_issur_melacha_motsaei_shabbat(self) -> None:
         """Test for issur melacha on Motsaei shabbat."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2018, 11, 10), location=coord)
-        assert not zman.issur_melacha_in_effect(datetime(2018, 11, 10, 17, 45))
+        zman = Zmanim(date=dt.date(2018, 11, 10), location=coord)
+        assert not zman.issur_melacha_in_effect(dt.datetime(2018, 11, 10, 17, 45))
 
     def test_issur_melacha_shavuot_morning(self) -> None:
         """Test for issur melacha on shavuot morning."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2019, 6, 9), location=coord)
-        assert zman.issur_melacha_in_effect(datetime(2019, 6, 9, 9))
+        zman = Zmanim(date=dt.date(2019, 6, 9), location=coord)
+        assert zman.issur_melacha_in_effect(dt.datetime(2019, 6, 9, 9))
 
     def test_issur_melacha_pesach_vi_morning(self) -> None:
         """Test for issur melacha on erev shvii shel pesach morning."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2019, 4, 25), location=coord)
-        assert not zman.issur_melacha_in_effect(datetime(2019, 4, 25, 9, 45))
+        zman = Zmanim(date=dt.date(2019, 4, 25), location=coord)
+        assert not zman.issur_melacha_in_effect(dt.datetime(2019, 4, 25, 9, 45))
 
     def test_issur_melacha_shavuot_evening(self) -> None:
         """Test for issur melacha on shavuot evening."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2019, 6, 8), location=coord)
-        assert zman.issur_melacha_in_effect(datetime(2019, 6, 8, 21, 45))
+        zman = Zmanim(date=dt.date(2019, 6, 8), location=coord)
+        assert zman.issur_melacha_in_effect(dt.datetime(2019, 6, 8, 21, 45))
 
     def test_issur_melacha_motsaei_shavuot(self) -> None:
         """Test for issur melacha on motsaei shavuot."""
         coord = Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
-        zman = Zmanim(date=date(2019, 6, 9), location=coord)
-        assert not zman.issur_melacha_in_effect(datetime(2019, 6, 9, 20, 30))
+        zman = Zmanim(date=dt.date(2019, 6, 9), location=coord)
+        assert not zman.issur_melacha_in_effect(dt.datetime(2019, 6, 9, 20, 30))
 
     def test_issur_melacha_pesach_ii_morning(self) -> None:
         """Test for issur melacha on the second day of pesach in the diaspora."""
         coord = Location(
             "New York", 40.7128, -74.0060, "America/New_York", diaspora=True
         )
-        zman = Zmanim(date=date(2019, 4, 21), location=coord)
-        assert zman.issur_melacha_in_effect(datetime(2019, 4, 21, 9))
+        zman = Zmanim(date=dt.date(2019, 4, 21), location=coord)
+        assert zman.issur_melacha_in_effect(dt.datetime(2019, 4, 21, 9))
 
     def test_issur_melacha_pesach_ii_evening(self) -> None:
         """Test for issur melacha on the eve of second day of pesach in the diaspora."""
         coord = Location(
             "New York", 40.7128, -74.0060, "America/New_York", diaspora=True
         )
-        zman = Zmanim(date=date(2019, 4, 20), location=coord)
-        assert zman.issur_melacha_in_effect(datetime(2019, 4, 20, 21, 45))
+        zman = Zmanim(date=dt.date(2019, 4, 20), location=coord)
+        assert zman.issur_melacha_in_effect(dt.datetime(2019, 4, 20, 21, 45))
 
     def test_issur_melacha_motsaei_pesach_ii(self) -> None:
         """Test for issur melacha on the end of second day of pesach in the diaspora."""
@@ -217,8 +217,8 @@ class TestZmanimAPI:
             timezone="America/New_York",
             diaspora=True,
         )
-        zman = Zmanim(date=date(2019, 4, 21), location=coord)
-        assert not zman.issur_melacha_in_effect(datetime(2019, 4, 21, 20, 30))
+        zman = Zmanim(date=dt.date(2019, 4, 21), location=coord)
+        assert not zman.issur_melacha_in_effect(dt.datetime(2019, 4, 21, 20, 30))
 
     def test_zmanim_localized_datetime(self) -> None:
         """Test for issur melacha if datetime is localized."""
@@ -229,8 +229,8 @@ class TestZmanimAPI:
             timezone="America/New_York",
             diaspora=True,
         )
-        _timezone = cast(tzinfo, coord.timezone)
-        zman = Zmanim(date=date(2019, 4, 21), location=coord)
+        _timezone = cast(dt.tzinfo, coord.timezone)
+        zman = Zmanim(date=dt.date(2019, 4, 21), location=coord)
         assert not zman.issur_melacha_in_effect(
-            datetime(2019, 4, 21, 20, 30, tzinfo=_timezone)
+            dt.datetime(2019, 4, 21, 20, 30, tzinfo=_timezone)
         )

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -1,5 +1,7 @@
 """Tests for the HebrewDate class."""
 
+import datetime as dt
+
 from hypothesis import given, strategies
 
 from hdate.hebrew_date import HebrewDate
@@ -58,11 +60,16 @@ def test_hebrew_date_comparisons_with_no_year(d1: HebrewDate, d2: HebrewDate) ->
     assert (d1 >= d2) == ((d1.month, d1.day) >= (d2.month, d2.day))
 
 
-@given(d1=valid_hebrew_date(), d2=valid_hebrew_date())
-def test_hebrew_date_addition(d1: HebrewDate, d2: HebrewDate) -> None:
+@given(
+    d1=valid_hebrew_date(),
+    delta=strategies.timedeltas(
+        min_value=dt.timedelta(days=-500), max_value=dt.timedelta(days=500)
+    ),
+)
+def test_hebrew_date_addition(d1: HebrewDate, delta: dt.timedelta) -> None:
     """Test HebrewDate addition and subtraction."""
-    diff = d1 - d2
-    assert d2 + diff == d1
+    d2 = d1 + delta
+    assert d2 - d1 == delta
 
 
 @given(d1=valid_hebrew_date(), d2=no_year_hebrew_date())

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -28,11 +28,31 @@ def valid_hebrew_date(draw: strategies.DrawFn) -> HebrewDate:
     return HebrewDate(year, month, day)
 
 
+@strategies.composite
+def no_year_hebrew_date(draw: strategies.DrawFn) -> HebrewDate:
+    """Generate a Hebrew date with no year."""
+    month = draw(strategies.sampled_from(list(Months)))
+    day = draw(strategies.integers(min_value=1, max_value=30))
+    return HebrewDate(0, month, day)
+
+
 @given(d1=valid_hebrew_date(), d2=valid_hebrew_date())
 def test_hebrew_date_comparisons(d1: HebrewDate, d2: HebrewDate) -> None:
     """Test that the HebrewDate class implements all comparison operators correctly."""
     assert (d1 == d2) == ((d1.year, d1.month, d1.day) == (d2.year, d2.month, d2.day))
+    assert (d1 != d2) == ((d1.year, d1.month, d1.day) != (d2.year, d2.month, d2.day))
     assert (d1 < d2) == ((d1.year, d1.month, d1.day) < (d2.year, d2.month, d2.day))
     assert (d1 > d2) == ((d1.year, d1.month, d1.day) > (d2.year, d2.month, d2.day))
     assert (d1 <= d2) == ((d1.year, d1.month, d1.day) <= (d2.year, d2.month, d2.day))
     assert (d1 >= d2) == ((d1.year, d1.month, d1.day) >= (d2.year, d2.month, d2.day))
+
+
+@given(d1=valid_hebrew_date(), d2=no_year_hebrew_date())
+def test_hebrew_date_comparisons_with_no_year(d1: HebrewDate, d2: HebrewDate) -> None:
+    """Test HebrewDatecomparison operators when there is no year."""
+    assert (d1 == d2) == ((d1.month, d1.day) == (d2.month, d2.day))
+    assert (d1 != d2) == ((d1.month, d1.day) != (d2.month, d2.day))
+    assert (d1 < d2) == ((d1.month, d1.day) < (d2.month, d2.day))
+    assert (d1 > d2) == ((d1.month, d1.day) > (d2.month, d2.day))
+    assert (d1 <= d2) == ((d1.month, d1.day) <= (d2.month, d2.day))
+    assert (d1 >= d2) == ((d1.month, d1.day) >= (d2.month, d2.day))

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -56,3 +56,10 @@ def test_hebrew_date_comparisons_with_no_year(d1: HebrewDate, d2: HebrewDate) ->
     assert (d1 > d2) == ((d1.month, d1.day) > (d2.month, d2.day))
     assert (d1 <= d2) == ((d1.month, d1.day) <= (d2.month, d2.day))
     assert (d1 >= d2) == ((d1.month, d1.day) >= (d2.month, d2.day))
+
+
+@given(d1=valid_hebrew_date(), d2=valid_hebrew_date())
+def test_hebrew_date_addition(d1: HebrewDate, d2: HebrewDate) -> None:
+    """Test HebrewDate addition and subtraction."""
+    diff = d1 - d2
+    assert d2 + diff == d1

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -63,3 +63,10 @@ def test_hebrew_date_addition(d1: HebrewDate, d2: HebrewDate) -> None:
     """Test HebrewDate addition and subtraction."""
     diff = d1 - d2
     assert d2 + diff == d1
+
+
+@given(d1=valid_hebrew_date(), d2=no_year_hebrew_date())
+def test_hebrew_date_addition_with_no_year(d1: HebrewDate, d2: HebrewDate) -> None:
+    """Test HebrewDate addition and subtraction when there is no year."""
+    diff = d1 - d2
+    assert d2 + diff == d1

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -24,14 +24,14 @@ def valid_hebrew_date(draw: strategies.DrawFn) -> HebrewDate:
         months.remove(Months.ADAR_II)
     month = draw(strategies.sampled_from(months))
 
-    days = HebrewDate(year).get_month_days(month)
+    days = HebrewDate(year).days_in_month(month)
     day = draw(strategies.integers(min_value=1, max_value=days))
 
     return HebrewDate(year, month, day)
 
 
 @strategies.composite
-def no_year_hebrew_date(draw: strategies.DrawFn) -> HebrewDate:
+def relative_hebrew_date(draw: strategies.DrawFn) -> HebrewDate:
     """Generate a Hebrew date with no year."""
     month = draw(strategies.sampled_from(list(Months)))
     day = draw(strategies.integers(min_value=1, max_value=30))
@@ -49,8 +49,8 @@ def test_hebrew_date_comparisons(d1: HebrewDate, d2: HebrewDate) -> None:
     assert (d1 >= d2) == ((d1.year, d1.month, d1.day) >= (d2.year, d2.month, d2.day))
 
 
-@given(d1=valid_hebrew_date(), d2=no_year_hebrew_date())
-def test_hebrew_date_comparisons_with_no_year(d1: HebrewDate, d2: HebrewDate) -> None:
+@given(d1=valid_hebrew_date(), d2=relative_hebrew_date())
+def test_relative_hebrew_date_comparisons(d1: HebrewDate, d2: HebrewDate) -> None:
     """Test HebrewDatecomparison operators when there is no year."""
     assert (d1 == d2) == ((d1.month, d1.day) == (d2.month, d2.day))
     assert (d1 != d2) == ((d1.month, d1.day) != (d2.month, d2.day))
@@ -71,7 +71,7 @@ def test_hebrew_date_addition(d1: HebrewDate, days: int) -> None:
     assert d2 - d1 == delta
 
 
-@given(d1=valid_hebrew_date(), d2=no_year_hebrew_date())
+@given(d1=valid_hebrew_date(), d2=relative_hebrew_date())
 def test_hebrew_date_addition_with_no_year(d1: HebrewDate, d2: HebrewDate) -> None:
     """Test HebrewDate addition and subtraction when there is no year."""
     diff = d2 - d1

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -7,7 +7,7 @@ from hypothesis import given, strategies
 from hdate.hebrew_date import HebrewDate
 from hdate.htables import Months
 
-MIN_YEAR = 1
+MIN_YEAR = 3762
 MAX_YEAR = 6000
 
 
@@ -62,12 +62,11 @@ def test_hebrew_date_comparisons_with_no_year(d1: HebrewDate, d2: HebrewDate) ->
 
 @given(
     d1=valid_hebrew_date(),
-    delta=strategies.timedeltas(
-        min_value=dt.timedelta(days=-500), max_value=dt.timedelta(days=500)
-    ),
+    days=strategies.integers(min_value=-500, max_value=500),
 )
-def test_hebrew_date_addition(d1: HebrewDate, delta: dt.timedelta) -> None:
+def test_hebrew_date_addition(d1: HebrewDate, days: int) -> None:
     """Test HebrewDate addition and subtraction."""
+    delta = dt.timedelta(days=days)
     d2 = d1 + delta
     assert d2 - d1 == delta
 
@@ -75,5 +74,5 @@ def test_hebrew_date_addition(d1: HebrewDate, delta: dt.timedelta) -> None:
 @given(d1=valid_hebrew_date(), d2=no_year_hebrew_date())
 def test_hebrew_date_addition_with_no_year(d1: HebrewDate, d2: HebrewDate) -> None:
     """Test HebrewDate addition and subtraction when there is no year."""
-    diff = d1 - d2
-    assert d2 + diff == d1
+    diff = d2 - d1
+    assert d1 + diff == d2

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -1,0 +1,38 @@
+"""Tests for the HebrewDate class."""
+
+from hypothesis import given, strategies
+
+from hdate.hebrew_date import HebrewDate
+from hdate.htables import Months
+
+MIN_YEAR = 1
+MAX_YEAR = 6000
+
+
+@strategies.composite
+def valid_hebrew_date(draw: strategies.DrawFn) -> HebrewDate:
+    """Generate a valid Hebrew date."""
+    year = draw(strategies.integers(min_value=MIN_YEAR, max_value=MAX_YEAR))
+
+    months = list(Months)
+    if HebrewDate(year).is_leap_year():
+        months.remove(Months.ADAR)
+    else:
+        months.remove(Months.ADAR_I)
+        months.remove(Months.ADAR_II)
+    month = draw(strategies.sampled_from(months))
+
+    days = HebrewDate(year).get_month_days(month)
+    day = draw(strategies.integers(min_value=1, max_value=days))
+
+    return HebrewDate(year, month, day)
+
+
+@given(d1=valid_hebrew_date(), d2=valid_hebrew_date())
+def test_hebrew_date_comparisons(d1: HebrewDate, d2: HebrewDate) -> None:
+    """Test that the HebrewDate class implements all comparison operators correctly."""
+    assert (d1 == d2) == ((d1.year, d1.month, d1.day) == (d2.year, d2.month, d2.day))
+    assert (d1 < d2) == ((d1.year, d1.month, d1.day) < (d2.year, d2.month, d2.day))
+    assert (d1 > d2) == ((d1.year, d1.month, d1.day) > (d2.year, d2.month, d2.day))
+    assert (d1 <= d2) == ((d1.year, d1.month, d1.day) <= (d2.year, d2.month, d2.day))
+    assert (d1 >= d2) == ((d1.year, d1.month, d1.day) >= (d2.year, d2.month, d2.day))

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 
+import pytest
 from hypothesis import given, strategies
 
 from hdate.hebrew_date import HebrewDate
@@ -60,6 +61,7 @@ def test_relative_hebrew_date_comparisons(d1: HebrewDate, d2: HebrewDate) -> Non
     assert (d1 >= d2) == ((d1.month, d1.day) >= (d2.month, d2.day))
 
 
+@pytest.mark.xfail(reason="Needs support for leap years")
 @given(
     d1=valid_hebrew_date(),
     days=strategies.integers(min_value=-500, max_value=500),
@@ -71,6 +73,7 @@ def test_hebrew_date_addition(d1: HebrewDate, days: int) -> None:
     assert d2 - d1 == delta
 
 
+@pytest.mark.xfail(reason="Needs support for leap years")
 @given(d1=valid_hebrew_date(), d2=relative_hebrew_date())
 def test_hebrew_date_addition_with_no_year(d1: HebrewDate, d2: HebrewDate) -> None:
     """Test HebrewDate addition and subtraction when there is no year."""

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -35,7 +35,8 @@ def valid_hebrew_date(draw: strategies.DrawFn) -> HebrewDate:
 def relative_hebrew_date(draw: strategies.DrawFn) -> HebrewDate:
     """Generate a Hebrew date with no year."""
     month = draw(strategies.sampled_from(list(Months)))
-    day = draw(strategies.integers(min_value=1, max_value=30))
+    max_day = HebrewDate().days_in_month(month)
+    day = draw(strategies.integers(min_value=1, max_value=max_day))
     return HebrewDate(0, month, day)
 
 

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -1,11 +1,9 @@
 """Test Zmanim objects."""
 
-import datetime
+import datetime as dt
 import random
 import sys
 from calendar import isleap
-from datetime import datetime as dt
-from datetime import timedelta as td
 from typing import Optional
 from zoneinfo import ZoneInfo
 
@@ -27,26 +25,26 @@ PUNTA_ARENAS_LNG = -70.9167
 
 
 def compare_dates(
-    date1: Optional[datetime.datetime],
-    date2: Optional[datetime.datetime],
+    date1: Optional[dt.datetime],
+    date2: Optional[dt.datetime],
     allow_grace: bool = False,
 ) -> None:
     """Compare 2 dates to be more or less equal."""
     if not (date1 or date2):
         assert date1 == date2
     else:
-        grace = td(minutes=5 if (not _ASTRAL or allow_grace) else 0)
+        grace = dt.timedelta(minutes=5 if (not _ASTRAL or allow_grace) else 0)
         assert date1 is not None
         assert date2 is not None
         assert date1 - grace <= date2 <= date1 + grace
 
 
-def compare_times(
-    time1: datetime.time, time2: datetime.time, allow_grace: bool = False
-) -> None:
+def compare_times(time1: dt.time, time2: dt.time, allow_grace: bool = False) -> None:
     """Compare times to be equal."""
     compare_dates(
-        dt.combine(dt.today(), time1), dt.combine(dt.today(), time2), allow_grace
+        dt.datetime.combine(dt.date.today(), time1),
+        dt.datetime.combine(dt.date.today(), time2),
+        allow_grace,
     )
 
 
@@ -60,21 +58,21 @@ class TestZmanim:
 
     @pytest.mark.parametrize("execution_number", list(range(5)))
     def test_same_doy_is_equal(
-        self, execution_number: int, random_date: datetime.date
+        self, execution_number: int, random_date: dt.date
     ) -> None:
         """Test two doy to be equal."""
         print(f"Run number {execution_number}")
         other_year = random.randint(500, 3000)
-        shift_day = datetime.timedelta(days=0)
+        shift_day = dt.timedelta(days=0)
         this_date = random_date
 
-        if isleap(this_date.year) != isleap(other_year) and this_date > datetime.date(
+        if isleap(this_date.year) != isleap(other_year) and this_date > dt.date(
             this_date.year, 2, 28
         ):
             if isleap(other_year):
-                shift_day = datetime.timedelta(days=-1)
+                shift_day = dt.timedelta(days=-1)
             else:
-                shift_day = datetime.timedelta(days=1)
+                shift_day = dt.timedelta(days=1)
 
         if (
             isleap(this_date.year)
@@ -84,7 +82,7 @@ class TestZmanim:
         ):
             # Special case we can't simply replace the year as there's
             # no leap day in the other year
-            other_date = datetime.date(other_year, 3, 1)
+            other_date = dt.date(other_year, 3, 1)
         else:
             other_date = this_date.replace(year=other_year) + shift_day
 
@@ -99,7 +97,7 @@ class TestZmanim:
 
     def test_extreme_zmanim(self) -> None:
         """Test that Zmanim north to 50 degrees latitude is correct."""
-        day = datetime.date(2024, 6, 18)
+        day = dt.date(2024, 6, 18)
         compare_times(
             Zmanim(
                 date=day,
@@ -113,7 +111,7 @@ class TestZmanim:
             )
             .zmanim["sunset"]
             .time(),
-            datetime.time(21, 22),
+            dt.time(21, 22),
             allow_grace=True,
         )
         compare_times(
@@ -129,13 +127,13 @@ class TestZmanim:
             )
             .zmanim["sunset"]
             .time(),
-            datetime.time(17, 31),
+            dt.time(17, 31),
             allow_grace=True,
         )
 
     def test_using_tzinfo(self) -> None:
         """Test tzinfo to be correct."""
-        day = datetime.date(2018, 9, 8)
+        day = dt.date(2018, 9, 8)
         timezone_str = "America/New_York"
         timezone = ZoneInfo(timezone_str)
         location_tz_str = Location(
@@ -145,25 +143,25 @@ class TestZmanim:
 
         compare_times(
             Zmanim(date=day, location=location_tz_str).zmanim["first_stars"].time(),
-            datetime.time(19, 47),
+            dt.time(19, 47),
         )
 
         compare_times(
             Zmanim(date=day, location=location).zmanim["first_stars"].time(),
-            datetime.time(19, 47),
+            dt.time(19, 47),
         )
 
     # Times are assumed for NYC.
     CANDLES_TEST = [
-        (dt(2018, 9, 7, 13, 1), 18, dt(2018, 9, 7, 19, 0), False),
-        (dt(2018, 9, 7, 19, 4), 18, dt(2018, 9, 7, 19, 0), True),
-        (dt(2018, 9, 8, 13, 1), 18, None, True),
-        (dt(2018, 9, 19, 22, 1), 18, None, False),
-        (dt(2018, 9, 9, 16, 1), 20, dt(2018, 9, 9, 18, 55), False),
-        (dt(2018, 9, 9, 19, 30), 18, dt(2018, 9, 9, 18, 57), True),
+        (dt.datetime(2018, 9, 7, 13, 1), 18, dt.datetime(2018, 9, 7, 19, 0), False),
+        (dt.datetime(2018, 9, 7, 19, 4), 18, dt.datetime(2018, 9, 7, 19, 0), True),
+        (dt.datetime(2018, 9, 8, 13, 1), 18, None, True),
+        (dt.datetime(2018, 9, 19, 22, 1), 18, None, False),
+        (dt.datetime(2018, 9, 9, 16, 1), 20, dt.datetime(2018, 9, 9, 18, 55), False),
+        (dt.datetime(2018, 9, 9, 19, 30), 18, dt.datetime(2018, 9, 9, 18, 57), True),
         # Candle lighting matches the time that would be havdalah.
-        (dt(2018, 9, 10, 8, 1), 18, dt(2018, 9, 10, 19, 55), True),
-        (dt(2018, 9, 10, 20, 20), 18, dt(2018, 9, 10, 19, 55), True),
+        (dt.datetime(2018, 9, 10, 8, 1), 18, dt.datetime(2018, 9, 10, 19, 55), True),
+        (dt.datetime(2018, 9, 10, 20, 20), 18, dt.datetime(2018, 9, 10, 19, 55), True),
     ]
 
     @pytest.mark.parametrize(
@@ -171,9 +169,9 @@ class TestZmanim:
     )
     def test_candle_lighting(
         self,
-        now: datetime.datetime,
+        now: dt.datetime,
         offset: int,
-        candle_lighting: Optional[datetime.datetime],
+        candle_lighting: Optional[dt.datetime],
         melacha_assur: bool,
     ) -> None:
         """Test candle lighting values."""
@@ -199,17 +197,17 @@ class TestZmanim:
 
     # Times are assumed for NYC.
     HAVDALAH_TEST = [
-        (dt(2018, 9, 7, 13, 1), 42, None, False),
-        (dt(2018, 9, 7, 20, 1), 42, None, True),
-        (dt(2018, 9, 8, 13, 1), 42, dt(2018, 9, 8, 19, 59), True),
-        (dt(2018, 9, 8, 13, 1), 0, dt(2018, 9, 8, 19, 58), True),
-        (dt(2018, 9, 19, 22, 1), 18, dt(2018, 9, 19, 19, 16), False),
-        (dt(2018, 9, 9, 16, 1), 0, None, False),
-        (dt(2018, 9, 9, 19, 30), 0, None, True),
-        (dt(2018, 9, 11, 16, 1), 0, dt(2018, 9, 11, 19, 53), True),
+        (dt.datetime(2018, 9, 7, 13, 1), 42, None, False),
+        (dt.datetime(2018, 9, 7, 20, 1), 42, None, True),
+        (dt.datetime(2018, 9, 8, 13, 1), 42, dt.datetime(2018, 9, 8, 19, 59), True),
+        (dt.datetime(2018, 9, 8, 13, 1), 0, dt.datetime(2018, 9, 8, 19, 58), True),
+        (dt.datetime(2018, 9, 19, 22, 1), 18, dt.datetime(2018, 9, 19, 19, 16), False),
+        (dt.datetime(2018, 9, 9, 16, 1), 0, None, False),
+        (dt.datetime(2018, 9, 9, 19, 30), 0, None, True),
+        (dt.datetime(2018, 9, 11, 16, 1), 0, dt.datetime(2018, 9, 11, 19, 53), True),
         # No havdalah in the middle of Yom Tov.
-        (dt(2018, 9, 10, 8, 1), 0, None, True),
-        (dt(2018, 9, 10, 20, 20), 0, None, True),
+        (dt.datetime(2018, 9, 10, 8, 1), 0, None, True),
+        (dt.datetime(2018, 9, 10, 20, 20), 0, None, True),
     ]
 
     @pytest.mark.parametrize(
@@ -217,9 +215,9 @@ class TestZmanim:
     )
     def test_havdalah(
         self,
-        now: datetime.datetime,
+        now: dt.datetime,
         offset: int,
-        havdalah: Optional[datetime.datetime],
+        havdalah: Optional[dt.datetime],
         melacha_assur: bool,
     ) -> None:
         """Test havdalah times."""
@@ -242,24 +240,24 @@ class TestZmanim:
 
     # Times are assumed for NYC.
     MOTZEI_SHABBAT_CHAG_TEST = [
-        (dt(2018, 9, 7, 13, 1), 42, False),
-        (dt(2018, 9, 7, 20, 1), 42, False),
-        (dt(2018, 9, 8, 13, 1), 42, False),
-        (dt(2018, 9, 8, 22, 1), 0, True),
-        (dt(2018, 9, 9, 16, 1), 0, False),
-        (dt(2018, 9, 9, 19, 30), 0, False),
-        (dt(2018, 9, 10, 16, 1), 0, False),
-        (dt(2018, 9, 10, 19, 30), 0, False),
-        (dt(2018, 9, 11, 16, 1), 0, False),
-        (dt(2018, 9, 11, 20, 1), 0, True),
-        (dt(2018, 9, 19, 22, 1), 18, True),
+        (dt.datetime(2018, 9, 7, 13, 1), 42, False),
+        (dt.datetime(2018, 9, 7, 20, 1), 42, False),
+        (dt.datetime(2018, 9, 8, 13, 1), 42, False),
+        (dt.datetime(2018, 9, 8, 22, 1), 0, True),
+        (dt.datetime(2018, 9, 9, 16, 1), 0, False),
+        (dt.datetime(2018, 9, 9, 19, 30), 0, False),
+        (dt.datetime(2018, 9, 10, 16, 1), 0, False),
+        (dt.datetime(2018, 9, 10, 19, 30), 0, False),
+        (dt.datetime(2018, 9, 11, 16, 1), 0, False),
+        (dt.datetime(2018, 9, 11, 20, 1), 0, True),
+        (dt.datetime(2018, 9, 19, 22, 1), 18, True),
     ]
 
     @pytest.mark.parametrize(
         ["now", "offset", "motzei_shabbat_chag"], MOTZEI_SHABBAT_CHAG_TEST
     )
     def test_motzei_shabbat_chag(
-        self, now: datetime.datetime, offset: int, motzei_shabbat_chag: bool
+        self, now: dt.datetime, offset: int, motzei_shabbat_chag: bool
     ) -> None:
         """Test motzei shabbat chag boolean is correct."""
         location_tz_str = Location(
@@ -277,27 +275,27 @@ class TestZmanim:
 
     # Times are assumed for NYC.
     EREV_SHABBAT_CHAG_TEST = [
-        (dt(2018, 9, 7, 13, 1), 42, True),  # fri
-        (dt(2018, 9, 7, 20, 1), 42, False),
-        (dt(2018, 9, 8, 13, 1), 42, False),  # sat
-        (dt(2018, 9, 8, 20, 1), 0, False),
-        (dt(2018, 9, 9, 16, 1), 0, True),  # erev rosh hashana
-        (dt(2018, 9, 9, 19, 30), 0, False),
-        (dt(2018, 9, 10, 16, 1), 0, False),  # rosh hashana I
-        (dt(2018, 9, 10, 19, 30), 0, False),
-        (dt(2018, 9, 11, 16, 1), 0, False),  # rosh hashana II
-        (dt(2018, 9, 11, 20, 1), 0, False),
-        (dt(2018, 9, 18, 13, 1), 18, True),  # erev yom kipur
-        (dt(2018, 9, 18, 22, 1), 18, False),
-        (dt(2018, 9, 19, 13, 1), 18, False),
-        (dt(2018, 9, 19, 22, 1), 18, False),
+        (dt.datetime(2018, 9, 7, 13, 1), 42, True),  # fri
+        (dt.datetime(2018, 9, 7, 20, 1), 42, False),
+        (dt.datetime(2018, 9, 8, 13, 1), 42, False),  # sat
+        (dt.datetime(2018, 9, 8, 20, 1), 0, False),
+        (dt.datetime(2018, 9, 9, 16, 1), 0, True),  # erev rosh hashana
+        (dt.datetime(2018, 9, 9, 19, 30), 0, False),
+        (dt.datetime(2018, 9, 10, 16, 1), 0, False),  # rosh hashana I
+        (dt.datetime(2018, 9, 10, 19, 30), 0, False),
+        (dt.datetime(2018, 9, 11, 16, 1), 0, False),  # rosh hashana II
+        (dt.datetime(2018, 9, 11, 20, 1), 0, False),
+        (dt.datetime(2018, 9, 18, 13, 1), 18, True),  # erev yom kipur
+        (dt.datetime(2018, 9, 18, 22, 1), 18, False),
+        (dt.datetime(2018, 9, 19, 13, 1), 18, False),
+        (dt.datetime(2018, 9, 19, 22, 1), 18, False),
     ]
 
     @pytest.mark.parametrize(
         ["now", "offset", "erev_shabbat_chag"], EREV_SHABBAT_CHAG_TEST
     )
     def test_erev_shabbat_hag(
-        self, now: datetime.datetime, offset: int, erev_shabbat_chag: bool
+        self, now: dt.datetime, offset: int, erev_shabbat_chag: bool
     ) -> None:
         """Test erev shabbat chag boolean is correct."""
         location_tz_str = Location(
@@ -315,8 +313,8 @@ class TestZmanim:
 
     def test_candle_lighting_erev_shabbat_is_yom_tov(self) -> None:
         """Test for candle lighting when erev shabbat is yom tov"""
-        day = datetime.date(2024, 10, 18)
-        actual_candle_lighting = datetime.datetime(
+        day = dt.date(2024, 10, 18)
+        actual_candle_lighting = dt.datetime(
             2024, 10, 18, 17, 52, 00, tzinfo=ZoneInfo("America/New_York")
         )
         coord = Location(


### PR DESCRIPTION
# Description

This improves the HebrewDate API:
- Completes comparison between dates (<=)
- Allows adding and subtracting dates without the need to go through the Julian day number
- Moves conversions from and to HebrewDate to be part of the class, allowing HebrewDate.from_gdate() and HebrewDate().to_gdate(), note that from_* are static methods, whereas to_* are instance methods.

# Closes issue(s)

  Fixes: #<issue number>

# Changes included (select only one)

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist

- [ ] Code passes tox
