### PR TITLE
HebrewDate API: make Months behave more intuitively 

### DIFF
--- a/hdate/date.py
+++ b/hdate/date.py
@@ -14,7 +14,7 @@ from typing import Generator, Optional, cast
 
 from hdate import htables
 from hdate.gematria import hebrew_number
-from hdate.hebrew_date import Days, HebrewDate, Months
+from hdate.hebrew_date import HebrewDate, Months, Weekday
 from hdate.htables import Holiday, HolidayTypes, Parasha
 from hdate.omer import Omer
 from hdate.translator import TranslatorMixin
@@ -171,11 +171,11 @@ class HDate(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
         return holidays_list
 
     @property
-    def dow(self) -> Days:
+    def dow(self) -> Weekday:
         """Return day of week enum."""
         # datetime weekday maps Monday->0, Sunday->6; this remaps to Sunday->1.
         _dow = self.gdate.weekday() + 2 if self.gdate.weekday() != 6 else 1
-        dow = Days(_dow)
+        dow = Weekday(_dow)
         dow.set_language(self._language)
         return dow
 
@@ -386,7 +386,7 @@ class HDate(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
             if (
                 days <= 22
                 and self.diaspora
-                and self.dow != Days.SATURDAY
+                and self.dow != Weekday.SATURDAY
                 or days <= 21
                 and not self.diaspora
             ):

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -14,8 +14,8 @@ from typing import Generator, Optional, cast
 
 from hdate import htables
 from hdate.gematria import hebrew_number
-from hdate.hebrew_date import HebrewDate
-from hdate.htables import Days, Holiday, HolidayTypes, Months, Parasha
+from hdate.hebrew_date import Days, HebrewDate, Months
+from hdate.htables import Holiday, HolidayTypes, Parasha
 from hdate.omer import Omer
 from hdate.translator import TranslatorMixin
 

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -198,27 +198,12 @@ class HebrewDate(TranslatorMixin):
 
     def to_jdn(self) -> int:
         """Compute Julian day number from HebrewDate."""
-        day = self.day
-        month = self.month.value if isinstance(self.month, Months) else self.month
-
-        if self.month == Months.ADAR_I:
-            month = 6
-        if self.month == Months.ADAR_II:
-            month = 6
-            day += 30
-
-        # Calculate days since 1,1,3744
-        day = HebrewDate._days_from_3744(self.year) + (59 * (month - 1) + 1) // 2 + day
-
-        # Special cases for this year
-        if long_cheshvan(self.year) and month > 2:  # long Heshvan
-            day += 1
-        if short_kislev(self.year) and month > 3:  # short Kislev
-            day -= 1
-        if is_leap_year(self.year) and month > 6:  # leap year
-            day += 30
-
-        # adjust to julian
+        month = Months.TISHREI
+        day = HebrewDate._days_from_3744(self.year)
+        while month != self.month:
+            day += self.days_in_month(month)
+            month = month.next_month(self.year)
+        day += self.day
         return day + 1715118
 
     @staticmethod

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -202,15 +202,12 @@ class HebrewDate(TranslatorMixin):
             else Months(self.month)  # type: ignore # pylint: disable=E1120
         )
         if self.year != 0:
-            leap_year = self.is_leap_year()
-            if (leap_year and self.month == Months.ADAR) or (
-                not leap_year and self.month in (Months.ADAR_I, Months.ADAR_II)
-            ):
+            if self.month not in Months.in_year(self.year):
                 raise ValueError(
                     f"{self.month} is not a valid month for year {self.year} "
-                    f"({'leap' if leap_year else 'non-leap'})"
+                    f"({'leap' if is_leap_year(self.year) else 'non-leap'})"
                 )
-        if not 0 < self.day <= (max_days := self.days_in_month(self.month)):
+        if not 0 < self.day <= (max_days := self.month.days(self.year)):
             raise ValueError(
                 f"Day {self.day} is illegal: "
                 f"legal values are 1-{max_days} for {self.month}"

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -240,7 +240,7 @@ class HebrewDate(TranslatorMixin):
             return NotImplemented
         days = other.days
         new = HebrewDate(self.year, self.month, self.day)
-        while days > 0:
+        while days != 0:
             if (days_left := cast(Months, new.month).days(new.year) - new.day) >= days:
                 new.day += days
                 break

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -22,7 +22,7 @@ PARTS_IN_WEEK = 7 * PARTS_IN_DAY
 PARTS_IN_MONTH = PARTS_IN_DAY + get_chalakim(12, 793)  # Fix for regular month
 
 
-class Days(TranslatorMixin, IntEnum):
+class Weekday(TranslatorMixin, IntEnum):
     """Enum class for the days of the week."""
 
     SUNDAY = 1
@@ -195,11 +195,7 @@ class HebrewDate(TranslatorMixin):
         return dt.timedelta(days=days)
 
     def to_jdn(self) -> int:
-        """
-        Compute Julian day from Hebrew day, month and year.
-
-        Return: julian day number
-        """
+        """Compute Julian day number from HebrewDate."""
         day = self.day
         month = self.month.value if isinstance(self.month, Months) else self.month
 
@@ -318,22 +314,9 @@ class HebrewDate(TranslatorMixin):
         """Return: True if the year is a leap year."""
         return is_leap_year(self.year)
 
-    def get_next_month(self, month: Months, year: int) -> Months:
-        """Return the next month."""
-
-        if HebrewDate(year).is_leap_year():
-            if month == Months.SHVAT:
-                return Months.ADAR_I
-            if month == Months.ADAR_I:
-                return Months.ADAR_II
-            if month == Months.ADAR_II:
-                return Months.NISAN
-        next_month = month + 1 if month < Months.ELUL else Months.TISHREI
-        return Months(next_month)  # type: ignore # pylint: disable=E1120
-
-    def dow(self) -> Days:
+    def dow(self) -> Weekday:
         """Return: day of the week."""
-        weekday = Days((self.to_jdn() + 1) % 7 + 1)
+        weekday = Weekday((self.to_jdn() + 1) % 7 + 1)
         weekday.set_language(self._language)
         return weekday
 

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 from dataclasses import dataclass
-from enum import IntEnum
+from enum import IntEnum, IntFlag
 from typing import TYPE_CHECKING, Callable, Optional, Union, cast
 
 import hdate.converters as conv
@@ -32,6 +32,31 @@ class Weekday(TranslatorMixin, IntEnum):
     THURSDAY = 5
     FRIDAY = 6
     SATURDAY = 7
+
+
+class ComparisonMode(IntFlag):
+    """Enum class for the comparison modes."""
+
+    STRICT: tuple[int, set[int]] = 0, set()
+    ADAR_IS_ADAR_I = 1, {6, 7}
+    ADAR_IS_ADAR_II = 2, {6, 8}
+    ADAR_IS_ANY = 3, {6 - 8}
+
+    if TYPE_CHECKING:
+        equal_month_values: set[int]
+
+    def __new__(cls, value: int, equal_month_values: set[int]) -> ComparisonMode:
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        obj.equal_month_values = equal_month_values
+        return obj
+
+    def __or__(self, other: object) -> ComparisonMode:
+        if not isinstance(other, ComparisonMode):
+            return NotImplemented
+        value = super().__or__(other)
+        value.equal_month_values = self.equal_month_values | other.equal_month_values
+        return value
 
 
 def short_kislev(year: int) -> bool:
@@ -68,7 +93,7 @@ class Months(TranslatorMixin, IntEnum):
     ELUL = 14, 6, 29
 
     if TYPE_CHECKING:
-        ordinal: int
+        biblical_order: int
         length: Union[int, Callable[[int], int]]
 
     def __new__(
@@ -76,8 +101,9 @@ class Months(TranslatorMixin, IntEnum):
     ) -> Months:
         obj = int.__new__(cls, value)
         obj._value_ = value
-        obj.ordinal = ordinal
+        obj.biblical_order = ordinal
         obj.length = days
+        obj.comparison_mode = ComparisonMode.STRICT
         return obj
 
     def __add__(self, value: object) -> Months:
@@ -109,6 +135,51 @@ class Months(TranslatorMixin, IntEnum):
                 raise ValueError("Year is required to calculate days for this month")
             return self.length(year)
         return self.length
+
+    def set_comparison_mode(self, mode: ComparisonMode) -> None:
+        """Set the comparison mode."""
+        self.comparison_mode = mode
+
+    def compare(self, other: Union[Months, int], order_type: str = "calendar") -> int:
+        """
+        Compare this month to another month.
+
+        The comparison can be either "calendar" or "biblical". When using the biblical
+        order, we consider NISAN as the first month. By default, we use the calendar
+        order starting at TISHREI.
+        """
+        value = self.value if order_type == "calendar" else self.biblical_order
+
+        if not isinstance(other, Months):
+            return value - other
+
+        other_value = other.value if order_type == "calendar" else other.biblical_order
+        mode = self.comparison_mode | other.comparison_mode
+
+        if (
+            self.value in mode.equal_month_values
+            and other.value in mode.equal_month_values
+        ):
+            return 0
+        return value - other_value
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, (Months, int)):
+            return NotImplemented
+        return self.compare(value) == 0
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, (Months, int)):
+            return NotImplemented
+        return self.compare(other) < 0
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, (Months, int)):
+            return NotImplemented
+        return self.compare(other) <= 0
+
+    def __hash__(self) -> int:
+        return IntEnum.__hash__(self)
 
 
 LONG_MONTHS = tuple(month for month in Months if month.length == 30)

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -170,10 +170,7 @@ class HebrewDate(TranslatorMixin):
         days = other.days
         new = HebrewDate(self.year, self.month, self.day)
         while days > 0:
-            if (
-                days_left := cast(Months, new.month).days(new.year)
-                - new.day
-            ) >= days:
+            if (days_left := cast(Months, new.month).days(new.year) - new.day) >= days:
                 new.day += days
                 break
             days -= days_left

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -58,14 +58,14 @@ class Months(TranslatorMixin, IntEnum):
     TEVET = 4, 10, 29
     SHVAT = 5, 11, 30
     ADAR = 6, 12, 29  # Adar in a non-leap year
-    NISAN = 7, 1, 30
-    IYYAR = 8, 2, 29
-    SIVAN = 9, 3, 30
-    TAMMUZ = 10, 4, 29
-    AV = 11, 5, 30
-    ELUL = 12, 6, 29
-    ADAR_I = 13, 12, 30  # Adar I in a leap year
-    ADAR_II = 14, 13, 29
+    ADAR_I = 7, 12, 30  # Adar I in a leap year
+    ADAR_II = 8, 13, 29
+    NISAN = 9, 1, 30
+    IYYAR = 10, 2, 29
+    SIVAN = 11, 3, 30
+    TAMMUZ = 12, 4, 29
+    AV = 13, 5, 30
+    ELUL = 14, 6, 29
 
     if TYPE_CHECKING:
         ordinal: int

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import datetime as dt
 from dataclasses import dataclass
+from enum import IntEnum
 from typing import Union
 
 import hdate.converters as conv
-from hdate.htables import CHANGING_MONTHS, LONG_MONTHS, SHORT_MONTHS, Days, Months
 from hdate.translator import TranslatorMixin
 
 
@@ -20,6 +20,56 @@ PARTS_IN_HOUR = 1080
 PARTS_IN_DAY = 24 * PARTS_IN_HOUR
 PARTS_IN_WEEK = 7 * PARTS_IN_DAY
 PARTS_IN_MONTH = PARTS_IN_DAY + get_chalakim(12, 793)  # Fix for regular month
+
+
+class Days(TranslatorMixin, IntEnum):
+    """Enum class for the days of the week."""
+
+    SUNDAY = 1
+    MONDAY = 2
+    TUESDAY = 3
+    WEDNESDAY = 4
+    THURSDAY = 5
+    FRIDAY = 6
+    SATURDAY = 7
+
+
+class Months(TranslatorMixin, IntEnum):
+    """Enum class for the Hebrew months."""
+
+    TISHREI = 1
+    MARCHESHVAN = 2
+    KISLEV = 3
+    TEVET = 4
+    SHVAT = 5
+    ADAR = 6
+    NISAN = 7
+    IYYAR = 8
+    SIVAN = 9
+    TAMMUZ = 10
+    AV = 11
+    ELUL = 12
+    ADAR_I = 13
+    ADAR_II = 14
+
+
+LONG_MONTHS = (
+    Months.TISHREI,
+    Months.SHVAT,
+    Months.ADAR_I,
+    Months.NISAN,
+    Months.SIVAN,
+    Months.AV,
+)
+SHORT_MONTHS = (
+    Months.TEVET,
+    Months.ADAR,
+    Months.ADAR_II,
+    Months.IYYAR,
+    Months.TAMMUZ,
+    Months.ELUL,
+)
+CHANGING_MONTHS = (Months.MARCHESHVAN, Months.KISLEV)
 
 
 @dataclass

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -310,22 +310,13 @@ class HebrewDate(TranslatorMixin):
 
     def days_in_month(self, month: Months) -> int:
         """Return the number of days in a month."""
-        if month in LONG_MONTHS:
-            return 30
-        if month in SHORT_MONTHS:
-            return 29
-        if self.year == 0 and month in CHANGING_MONTHS:
-            # Special case for relative dates, return the maximum number of days
-            return 30
-        if month == Months.KISLEV:
-            return 29 if self.short_kislev() else 30
-        if month == Months.MARCHESHVAN:
-            return 30 if self.long_cheshvan() else 29
-        return 0
+        if month in CHANGING_MONTHS:
+            return month.days(self.year)
+        return month.days()
 
     def is_leap_year(self) -> bool:
         """Return: True if the year is a leap year."""
-        return self.year % 19 in (0, 3, 6, 8, 11, 14, 17)
+        return is_leap_year(self.year)
 
     def get_next_month(self, month: Months, year: int) -> Months:
         """Return the next month."""

--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -171,15 +171,15 @@ class HebrewDate(TranslatorMixin):
         new = HebrewDate(self.year, self.month, self.day)
         while days > 0:
             if (
-                days_left := self.days_in_month(
-                    Months(new.month)  # type: ignore # pylint: disable=E1120
-                )
+                days_left := cast(Months, new.month).days(new.year)
                 - new.day
             ) >= days:
                 new.day += days
                 break
             days -= days_left
             new.month = cast(Months, new.month).next_month(new.year)
+            if new.month == Months.TISHREI:
+                new.year += 1
             new.day = 0
         return new
 
@@ -293,9 +293,7 @@ class HebrewDate(TranslatorMixin):
 
     def days_in_month(self, month: Months) -> int:
         """Return the number of days in a month."""
-        if month in CHANGING_MONTHS:
-            return month.days(self.year)
-        return month.days()
+        return month.days(self.year)
 
     def is_leap_year(self) -> bool:
         """Return: True if the year is a leap year."""

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import Enum, IntEnum, auto
 from typing import Callable, Union
 
-from hdate.hebrew_date import CHANGING_MONTHS, LONG_MONTHS, Days, HebrewDate, Months
+from hdate.hebrew_date import CHANGING_MONTHS, LONG_MONTHS, HebrewDate, Months, Weekday
 from hdate.translator import TranslatorMixin
 
 
@@ -372,7 +372,7 @@ def year_is_before(year: int) -> Callable[[HebrewDate], bool]:
 
 
 def move_if_not_on_dow(
-    original: int, replacement: int, dow_not_orig: Days, dow_replacement: Days
+    original: int, replacement: int, dow_not_orig: Weekday, dow_replacement: Weekday
 ) -> Callable[[HebrewDate], bool]:
     """
     Return a lambda function.
@@ -442,7 +442,7 @@ HOLIDAYS = (
         "tzom_gedaliah",
         ((3, 4), Months.TISHREI),
         "",
-        [move_if_not_on_dow(3, 4, Days.SATURDAY, Days.SUNDAY)],
+        [move_if_not_on_dow(3, 4, Weekday.SATURDAY, Weekday.SUNDAY)],
     ),
     Holiday(HolidayTypes.EREV_YOM_TOV, "erev_yom_kippur", (9, Months.TISHREI), "", []),
     Holiday(HolidayTypes.YOM_TOV, "yom_kippur", (10, Months.TISHREI), "", []),
@@ -483,7 +483,10 @@ HOLIDAYS = (
         "taanit_esther",
         ((11, 13), (Months.ADAR, Months.ADAR_II)),
         "",
-        [move_if_not_on_dow(13, 11, Days.SATURDAY, Days.THURSDAY), correct_adar()],
+        [
+            move_if_not_on_dow(13, 11, Weekday.SATURDAY, Weekday.THURSDAY),
+            correct_adar(),
+        ],
     ),
     Holiday(
         HolidayTypes.MELACHA_PERMITTED_HOLIDAY,
@@ -521,8 +524,8 @@ HOLIDAYS = (
         [
             year_is_after(5708),
             year_is_before(5764),
-            move_if_not_on_dow(5, 4, Days.FRIDAY, Days.THURSDAY)  # type: ignore
-            or move_if_not_on_dow(5, 3, Days.SATURDAY, Days.THURSDAY),
+            move_if_not_on_dow(5, 4, Weekday.FRIDAY, Weekday.THURSDAY)  # type: ignore
+            or move_if_not_on_dow(5, 3, Weekday.SATURDAY, Weekday.THURSDAY),
         ],
     ),
     Holiday(
@@ -532,9 +535,9 @@ HOLIDAYS = (
         "",
         [
             year_is_after(5763),
-            move_if_not_on_dow(5, 4, Days.FRIDAY, Days.THURSDAY)  # type: ignore
-            or move_if_not_on_dow(5, 3, Days.SATURDAY, Days.THURSDAY)
-            or move_if_not_on_dow(5, 6, Days.MONDAY, Days.TUESDAY),
+            move_if_not_on_dow(5, 4, Weekday.FRIDAY, Weekday.THURSDAY)  # type: ignore
+            or move_if_not_on_dow(5, 3, Weekday.SATURDAY, Weekday.THURSDAY)
+            or move_if_not_on_dow(5, 6, Weekday.MONDAY, Weekday.TUESDAY),
         ],
     ),
     Holiday(HolidayTypes.MINOR_HOLIDAY, "lag_bomer", (18, Months.IYYAR), "", []),
@@ -545,14 +548,14 @@ HOLIDAYS = (
         "tzom_tammuz",
         ((17, 18), Months.TAMMUZ),
         "",
-        [move_if_not_on_dow(17, 18, Days.SATURDAY, Days.SUNDAY)],
+        [move_if_not_on_dow(17, 18, Weekday.SATURDAY, Weekday.SUNDAY)],
     ),
     Holiday(
         HolidayTypes.FAST_DAY,
         "tisha_bav",
         ((9, 10), Months.AV),
         "",
-        [move_if_not_on_dow(9, 10, Days.SATURDAY, Days.SUNDAY)],
+        [move_if_not_on_dow(9, 10, Weekday.SATURDAY, Weekday.SUNDAY)],
     ),
     Holiday(HolidayTypes.MINOR_HOLIDAY, "tu_bav", (15, Months.AV), "", []),
     Holiday(
@@ -561,21 +564,8 @@ HOLIDAYS = (
         ((26, 27, 28), Months.NISAN),
         "",
         [
-            move_if_not_on_dow(27, 28, Days.SUNDAY, Days.MONDAY)  # type: ignore
-            or move_if_not_on_dow(27, 26, Days.FRIDAY, Days.THURSDAY),
-            year_is_after(5718),
-        ],
-    ),
-    Holiday(
-        HolidayTypes.MEMORIAL_DAY,
-        "yom_hazikaron",
-        ((2, 3, 4), Months.IYYAR),
-        "",
-        [
-            year_is_after(5708),
-            year_is_before(5764),
-            move_if_not_on_dow(4, 3, Days.THURSDAY, Days.WEDNESDAY)  # type: ignore
-            or move_if_not_on_dow(4, 2, Days.FRIDAY, Days.WEDNESDAY),
+            move_if_not_on_dow(27, 28, Weekday.SUNDAY, Weekday.MONDAY)  # type: ignore
+            or move_if_not_on_dow(4, 2, Weekday.FRIDAY, Weekday.WEDNESDAY),
         ],
     ),
     Holiday(
@@ -585,9 +575,11 @@ HOLIDAYS = (
         "",
         [
             year_is_after(5763),
-            move_if_not_on_dow(4, 3, Days.THURSDAY, Days.WEDNESDAY)  # type: ignore
-            or move_if_not_on_dow(4, 2, Days.FRIDAY, Days.WEDNESDAY)
-            or move_if_not_on_dow(4, 5, Days.SUNDAY, Days.MONDAY),
+            move_if_not_on_dow(
+                4, 3, Weekday.THURSDAY, Weekday.WEDNESDAY
+            )  # type: ignore
+            or move_if_not_on_dow(4, 2, Weekday.FRIDAY, Weekday.WEDNESDAY)
+            or move_if_not_on_dow(4, 5, Weekday.SUNDAY, Weekday.MONDAY),
         ],
     ),
     Holiday(
@@ -621,7 +613,10 @@ HOLIDAYS = (
         "rabin_memorial_day",
         ((11, 12), Months.MARCHESHVAN),
         "ISRAEL",
-        [move_if_not_on_dow(12, 11, Days.FRIDAY, Days.THURSDAY), year_is_after(5757)],
+        [
+            move_if_not_on_dow(12, 11, Weekday.FRIDAY, Weekday.THURSDAY),
+            year_is_after(5757),
+        ],
     ),
     Holiday(
         HolidayTypes.MEMORIAL_DAY,

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -565,7 +565,7 @@ HOLIDAYS = (
         "",
         [
             move_if_not_on_dow(27, 28, Weekday.SUNDAY, Weekday.MONDAY)  # type: ignore
-            or move_if_not_on_dow(4, 2, Weekday.FRIDAY, Weekday.WEDNESDAY),
+            or move_if_not_on_dow(27, 26, Weekday.FRIDAY, Weekday.THURSDAY),
             year_is_after(5718),
         ],
     ),

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -566,6 +566,21 @@ HOLIDAYS = (
         [
             move_if_not_on_dow(27, 28, Weekday.SUNDAY, Weekday.MONDAY)  # type: ignore
             or move_if_not_on_dow(4, 2, Weekday.FRIDAY, Weekday.WEDNESDAY),
+            year_is_after(5718),
+        ],
+    ),
+    Holiday(
+        HolidayTypes.MEMORIAL_DAY,
+        "yom_hazikaron",
+        ((2, 3, 4), Months.IYYAR),
+        "",
+        [
+            year_is_after(5708),
+            year_is_before(5764),
+            move_if_not_on_dow(
+                4, 3, Weekday.THURSDAY, Weekday.WEDNESDAY
+            )  # type: ignore
+            or move_if_not_on_dow(4, 2, Weekday.FRIDAY, Weekday.WEDNESDAY),
         ],
     ),
     Holiday(

--- a/hdate/htables.py
+++ b/hdate/htables.py
@@ -3,11 +3,10 @@
 import datetime as dt
 from dataclasses import dataclass
 from enum import Enum, IntEnum, auto
-from typing import Callable, TypeVar, Union
+from typing import Callable, Union
 
+from hdate.hebrew_date import CHANGING_MONTHS, LONG_MONTHS, Days, HebrewDate, Months
 from hdate.translator import TranslatorMixin
-
-HebrewDateT = TypeVar("HebrewDateT", bound="HebrewDate")  # type: ignore # noqa: F821
 
 
 def erange(start: Enum, end: Enum) -> list[Enum]:
@@ -352,57 +351,7 @@ PARASHA_SEQUENCES: dict[tuple[int, ...], tuple[Enum, ...]] = {
 }
 
 
-class Days(TranslatorMixin, IntEnum):
-    """Enum class for the days of the week."""
-
-    SUNDAY = 1
-    MONDAY = 2
-    TUESDAY = 3
-    WEDNESDAY = 4
-    THURSDAY = 5
-    FRIDAY = 6
-    SATURDAY = 7
-
-
-class Months(TranslatorMixin, IntEnum):
-    """Enum class for the Hebrew months."""
-
-    TISHREI = 1
-    MARCHESHVAN = 2
-    KISLEV = 3
-    TEVET = 4
-    SHVAT = 5
-    ADAR = 6
-    NISAN = 7
-    IYYAR = 8
-    SIVAN = 9
-    TAMMUZ = 10
-    AV = 11
-    ELUL = 12
-    ADAR_I = 13
-    ADAR_II = 14
-
-
-LONG_MONTHS = (
-    Months.TISHREI,
-    Months.SHVAT,
-    Months.ADAR_I,
-    Months.NISAN,
-    Months.SIVAN,
-    Months.AV,
-)
-SHORT_MONTHS = (
-    Months.TEVET,
-    Months.ADAR,
-    Months.ADAR_II,
-    Months.IYYAR,
-    Months.TAMMUZ,
-    Months.ELUL,
-)
-CHANGING_MONTHS = (Months.MARCHESHVAN, Months.KISLEV)
-
-
-def year_is_after(year: int) -> Callable[[HebrewDateT], bool]:
+def year_is_after(year: int) -> Callable[[HebrewDate], bool]:
     """
     Return a lambda function.
 
@@ -412,7 +361,7 @@ def year_is_after(year: int) -> Callable[[HebrewDateT], bool]:
     return lambda x: x.year > year
 
 
-def year_is_before(year: int) -> Callable[[HebrewDateT], bool]:
+def year_is_before(year: int) -> Callable[[HebrewDate], bool]:
     """
     Return a lambda function.
 
@@ -424,7 +373,7 @@ def year_is_before(year: int) -> Callable[[HebrewDateT], bool]:
 
 def move_if_not_on_dow(
     original: int, replacement: int, dow_not_orig: Days, dow_replacement: Days
-) -> Callable[[HebrewDateT], bool]:
+) -> Callable[[HebrewDate], bool]:
     """
     Return a lambda function.
 
@@ -437,7 +386,7 @@ def move_if_not_on_dow(
     )
 
 
-def correct_adar() -> Callable[[HebrewDateT], Union[bool, Callable[[], bool]]]:
+def correct_adar() -> Callable[[HebrewDate], Union[bool, Callable[[], bool]]]:
     """
     Return a lambda function.
 
@@ -451,7 +400,7 @@ def correct_adar() -> Callable[[HebrewDateT], Union[bool, Callable[[], bool]]]:
     )
 
 
-def not_rosh_chodesh() -> Callable[[HebrewDateT], bool]:
+def not_rosh_chodesh() -> Callable[[HebrewDate], bool]:
     """The 1st of Tishrei is not Rosh Chodesh."""
     return lambda x: not (x.month == Months.TISHREI and x.day == 1)
 
@@ -481,7 +430,7 @@ class Holiday(TranslatorMixin):
         tuple[Union[int, tuple[int, ...]], Union[Months, tuple[Months, ...]]], tuple[()]
     ]
     israel_diaspora: str
-    date_functions_list: list[Callable[[HebrewDateT], Union[bool, Callable[[], bool]]]]
+    date_functions_list: list[Callable[[HebrewDate], Union[bool, Callable[[], bool]]]]
 
 
 HOLIDAYS = (

--- a/hdate/omer.py
+++ b/hdate/omer.py
@@ -8,8 +8,7 @@ from typing import Union
 from num2words import lang_HE, num2words
 
 from hdate.gematria import hebrew_number
-from hdate.hebrew_date import HebrewDate
-from hdate.htables import Months
+from hdate.hebrew_date import HebrewDate, Months
 from hdate.translator import TranslatorMixin
 
 

--- a/hdate/tekufot.py
+++ b/hdate/tekufot.py
@@ -14,8 +14,7 @@ from datetime import tzinfo
 from enum import Enum
 from typing import Union
 
-from hdate.hebrew_date import HebrewDate
-from hdate.htables import Months
+from hdate.hebrew_date import HebrewDate, Months
 from hdate.location import Location
 from hdate.translator import TranslatorMixin
 from hdate.zmanim import Zmanim

--- a/hdate/translations.py
+++ b/hdate/translations.py
@@ -191,7 +191,7 @@ TRANSLATIONS = {
             "matot_masei": "Matot-Masei",
             "nitzavim_vayeilech": "Nitzavim-Vayeilech",
         },
-        "Days": {
+        "Weekday": {
             "sunday": "Sunday",
             "monday": "Monday",
             "tuesday": "Tuesday",
@@ -408,7 +408,7 @@ TRANSLATIONS = {
             "matot_masei": "Matot-Massei",
             "nitzavim_vayeilech": "Nitzavim-Vayelekh",
         },
-        "Days": {
+        "Weekday": {
             "sunday": "Dimanche",
             "monday": "Lundi",
             "tuesday": "Mardi",
@@ -625,7 +625,7 @@ TRANSLATIONS = {
             "matot_masei": "מטות מסעי",
             "nitzavim_vayeilech": "נצבים-וילך",
         },
-        "Days": {
+        "Weekday": {
             "sunday": "יום ראשון",
             "monday": "יום שני",
             "tuesday": "יום שלישי",

--- a/hdate/translations/en.json
+++ b/hdate/translations/en.json
@@ -182,7 +182,7 @@
         "matot_masei": "Matot-Masei",
         "nitzavim_vayeilech": "Nitzavim-Vayeilech"
     },
-    "Days": {
+    "Weekday": {
         "sunday": "Sunday",
         "monday": "Monday",
         "tuesday": "Tuesday",

--- a/hdate/translations/fr.json
+++ b/hdate/translations/fr.json
@@ -182,7 +182,7 @@
         "matot_masei": "Matot-Massei",
         "nitzavim_vayeilech": "Nitzavim-Vayelekh"
     },
-    "Days": {
+    "Weekday": {
         "sunday": "Dimanche",
         "monday": "Lundi",
         "tuesday": "Mardi",

--- a/hdate/translations/he.json
+++ b/hdate/translations/he.json
@@ -182,7 +182,7 @@
         "matot_masei": "מטות מסעי",
         "nitzavim_vayeilech": "נצבים-וילך"
     },
-    "Days": {
+    "Weekday": {
         "sunday": "יום ראשון",
         "monday": "יום שני",
         "tuesday": "יום שלישי",

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:8fd85e2dc94d3c3b2db6941cb0f18a42e84b585148a0c5c2dfc79712d1baf25e"
+content_hash = "sha256:393dd5043a59d83bd9c77760f0873951307bfc105ed5571323460ac4a468695c"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -554,7 +554,7 @@ name = "importlib-metadata"
 version = "7.1.0"
 requires_python = ">=3.8"
 summary = "Read metadata from Python packages"
-groups = ["dev"]
+groups = ["dev", "test"]
 marker = "python_version < \"3.10\""
 dependencies = [
     "typing-extensions>=3.6.4; python_version < \"3.8\"",
@@ -959,6 +959,21 @@ files = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "3.16.0"
+requires_python = ">=3.9"
+summary = "Pytest plugin to randomly order tests and control random.seed."
+groups = ["test"]
+dependencies = [
+    "importlib-metadata>=3.6; python_version < \"3.10\"",
+    "pytest",
+]
+files = [
+    {file = "pytest_randomly-3.16.0-py3-none-any.whl", hash = "sha256:8633d332635a1a0983d3bba19342196807f6afb17c3eef78e02c2f85dade45d6"},
+    {file = "pytest_randomly-3.16.0.tar.gz", hash = "sha256:11bf4d23a26484de7860d82f726c0629837cf4064b79157bd18ec9d41d7feb26"},
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.6.1"
 requires_python = ">=3.8"
@@ -1296,7 +1311,7 @@ name = "zipp"
 version = "3.19.2"
 requires_python = ">=3.8"
 summary = "Backport of pathlib-compatible object wrapper for zip files"
-groups = ["dev"]
+groups = ["dev", "test"]
 marker = "python_version < \"3.10\""
 files = [
     {file = "zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:393dd5043a59d83bd9c77760f0873951307bfc105ed5571323460ac4a468695c"
+content_hash = "sha256:8fd85e2dc94d3c3b2db6941cb0f18a42e84b585148a0c5c2dfc79712d1baf25e"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -554,7 +554,7 @@ name = "importlib-metadata"
 version = "7.1.0"
 requires_python = ">=3.8"
 summary = "Read metadata from Python packages"
-groups = ["dev", "test"]
+groups = ["dev"]
 marker = "python_version < \"3.10\""
 dependencies = [
     "typing-extensions>=3.6.4; python_version < \"3.8\"",
@@ -959,21 +959,6 @@ files = [
 ]
 
 [[package]]
-name = "pytest-randomly"
-version = "3.16.0"
-requires_python = ">=3.9"
-summary = "Pytest plugin to randomly order tests and control random.seed."
-groups = ["test"]
-dependencies = [
-    "importlib-metadata>=3.6; python_version < \"3.10\"",
-    "pytest",
-]
-files = [
-    {file = "pytest_randomly-3.16.0-py3-none-any.whl", hash = "sha256:8633d332635a1a0983d3bba19342196807f6afb17c3eef78e02c2f85dade45d6"},
-    {file = "pytest_randomly-3.16.0.tar.gz", hash = "sha256:11bf4d23a26484de7860d82f726c0629837cf4064b79157bd18ec9d41d7feb26"},
-]
-
-[[package]]
 name = "pytest-xdist"
 version = "3.6.1"
 requires_python = ">=3.8"
@@ -1311,7 +1296,7 @@ name = "zipp"
 version = "3.19.2"
 requires_python = ">=3.8"
 summary = "Backport of pathlib-compatible object wrapper for zip files"
-groups = ["dev", "test"]
+groups = ["dev"]
 marker = "python_version < \"3.10\""
 files = [
     {file = "zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:35202924964faccffe16213901f4a09e19ef7610079ed2fb435d00d3ea1b85ae"
+content_hash = "sha256:8fd85e2dc94d3c3b2db6941cb0f18a42e84b585148a0c5c2dfc79712d1baf25e"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -55,7 +55,7 @@ name = "attrs"
 version = "24.3.0"
 requires_python = ">=3.8"
 summary = "Classes Without Boilerplate"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "attrs-24.3.0-py3-none-any.whl", hash = "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"},
     {file = "attrs-24.3.0.tar.gz", hash = "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff"},
@@ -452,6 +452,17 @@ files = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+requires_python = ">=3.8"
+summary = "execnet: rapid multi-Python deployment"
+groups = ["test"]
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[[package]]
 name = "filelock"
 version = "3.16.1"
 requires_python = ">=3.8"
@@ -491,18 +502,18 @@ files = [
 
 [[package]]
 name = "hypothesis"
-version = "6.123.2"
+version = "6.123.7"
 requires_python = ">=3.9"
 summary = "A library for property-based testing"
-groups = ["dev"]
+groups = ["test"]
 dependencies = [
     "attrs>=22.2.0",
     "exceptiongroup>=1.0.0; python_version < \"3.11\"",
     "sortedcontainers<3.0.0,>=2.1.0",
 ]
 files = [
-    {file = "hypothesis-6.123.2-py3-none-any.whl", hash = "sha256:0a8bf07753f1436f1b8697a13ea955f3fef3ef7b477c2972869b1d142bcdb30e"},
-    {file = "hypothesis-6.123.2.tar.gz", hash = "sha256:02c25552783764146b191c69eef69d8375827b58a75074055705ab8fdbc95fc5"},
+    {file = "hypothesis-6.123.7-py3-none-any.whl", hash = "sha256:292d5cd90e1665da53cfe74082187488cf48292c45ca191550d661aee6d52397"},
+    {file = "hypothesis-6.123.7.tar.gz", hash = "sha256:c88f21fba1e8f893a43c04ca422acdf13b182b8272b4d530f5bbaa753e381232"},
 ]
 
 [[package]]
@@ -948,6 +959,21 @@ files = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+requires_python = ">=3.8"
+summary = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+groups = ["test"]
+dependencies = [
+    "execnet>=2.1",
+    "pytest>=7.0.0",
+]
+files = [
+    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
+    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+]
+
+[[package]]
 name = "pytz"
 version = "2024.2"
 summary = "World timezone definitions, modern and historical"
@@ -1047,7 +1073,7 @@ files = [
 name = "sortedcontainers"
 version = "2.4.0"
 summary = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
@@ -1155,7 +1181,7 @@ name = "syrupy"
 version = "4.8.0"
 requires_python = ">=3.8.1"
 summary = "Pytest Snapshot Test Utility"
-groups = ["dev"]
+groups = ["test"]
 dependencies = [
     "pytest<9.0.0,>=7.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ test = [
     "pytest-xdist>=3.6.1",
     "hypothesis>=6.123.7",
     "syrupy>=4.8.0",
-    "pytest-randomly>=3.16.0",
 ]
 
 [tool.bumpversion]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ test = [
     "pytest-xdist>=3.6.1",
     "hypothesis>=6.123.7",
     "syrupy>=4.8.0",
+    "pytest-randomly>=3.16.0",
 ]
 
 [tool.bumpversion]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ max-line-length = "88"
 # Show summary output for all types of failures
 # Run doctest that are part of docstrings
 # Run doctest in RST files
-addopts = "-ra --doctest-modules --doctest-glob=*.rst"
+addopts = "-ra --doctest-modules --doctest-glob=*.rst -n auto"
 
 [dependency-groups]
 dev = [
@@ -53,12 +53,13 @@ dev = [
     "flake8>=7.1.1",
     "mypy>=1.13.0",
     "pytest-profiling>=1.8.1",
-    "hypothesis>=6.123.2",
-    "syrupy>=4.8.0",
 ]
 test = [
     "pytest>=8.3.3",
     "pytest-coverage>=0.0",
+    "pytest-xdist>=3.6.1",
+    "hypothesis>=6.123.7",
+    "syrupy>=4.8.0",
 ]
 
 [tool.bumpversion]

--- a/tests/__snapshots__/test_hebrew_date.ambr
+++ b/tests/__snapshots__/test_hebrew_date.ambr
@@ -1,0 +1,13 @@
+# serializer version: 1
+# name: test_from_gdate_snapshot
+  HebrewDate(year=5785, month=<Months.TEVET: 4>, day=5)
+# ---
+# name: test_from_jdn_snapshot
+  HebrewDate(year=5760, month=<Months.TEVET: 4>, day=23)
+# ---
+# name: test_to_gdate_snapshot
+  datetime.date(2025, 1, 5)
+# ---
+# name: test_to_jdn_snapshot
+  2460681
+# ---

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -5,8 +5,7 @@ import datetime as dt
 import pytest
 
 from hdate import converters as conv
-from hdate.hebrew_date import HebrewDate
-from hdate.htables import Months
+from hdate.hebrew_date import HebrewDate, Months
 
 
 class TestConverters:

--- a/tests/test_gematria.py
+++ b/tests/test_gematria.py
@@ -1,8 +1,7 @@
 """Test hebrew_number"""
 
-import random
-
 import pytest
+from hypothesis import given, strategies
 
 from hdate import gematria
 
@@ -27,16 +26,19 @@ def test_hebrew_number(number: int, expected_string: str, expected_short: str) -
     assert gematria.hebrew_number(number) == expected_string
 
 
-def test_illegal_value() -> None:
+@given(
+    number=strategies.one_of(
+        strategies.integers(max_value=-1), strategies.integers(min_value=10001)
+    )
+)
+def test_illegal_value(number: int) -> None:
     """Test unsupported numbers."""
     with pytest.raises(ValueError):
-        gematria.hebrew_number(random.randint(10000, 20000))
-    with pytest.raises(ValueError):
-        gematria.hebrew_number(random.randint(-100, -1))
+        gematria.hebrew_number(number)
 
 
-def test_hebrew_number_hebrew_false() -> None:
+@given(number=strategies.integers(min_value=0, max_value=10000))
+def test_hebrew_number_hebrew_false(number: int) -> None:
     """Test returning a non-hebrew number."""
-    number = random.randint(0, 100000)
     assert gematria.hebrew_number(number, language="english") == str(number)
     assert gematria.hebrew_number(number, language="english", short=True) == str(number)

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from typing import Union
 
 import pytest
+from hypothesis import given, strategies
 
 from hdate import HDate, HebrewDate
 from hdate.hebrew_date import Months
@@ -885,10 +886,11 @@ class TestHDateReading:
         # VeZot Habracha in Israel always falls on 22 of Tishri
         assert mydate.get_reading() == 54
 
-    @pytest.mark.parametrize("year", range(5740, 5800))
-    def test_nitzavim_always_before_rosh_hashana(self, year: int) -> None:
+    @pytest.mark.parametrize("diaspora", [True, False])
+    @given(year=strategies.integers(min_value=4000, max_value=6000))
+    def test_nitzavim_always_before_rosh_hashana(self, year: int, diaspora: bool) -> None:
         """A property: Nitzavim alway falls before rosh hashana."""
-        mydate = HDate(language="english", diaspora=False)
+        mydate = HDate(language="english", diaspora=diaspora)
         mydate.hdate = HebrewDate(year, Months.TISHREI, 1)
         tdelta = dt.timedelta((12 - mydate.gdate.weekday()) % 7 - 7)
         # Go back to the previous shabbat
@@ -896,10 +898,11 @@ class TestHDateReading:
         print("Testing date: {mydate} which is {tdelta} days before Rosh Hashana")
         assert mydate.get_reading() in [51, 61]
 
-    @pytest.mark.parametrize("year", range(5740, 5800))
-    def test_vayelech_or_haazinu_always_after_rosh_hashana(self, year: int) -> None:
+    @pytest.mark.parametrize("diaspora", [True, False])
+    @given(year=strategies.integers(min_value=4000, max_value=6000))
+    def test_vayelech_or_haazinu_always_after_rosh_hashana(self, year: int, diaspora: bool) -> None:
         """A property: Vayelech or Haazinu always falls after rosh hashana."""
-        mydate = HDate(language="english", diaspora=True)
+        mydate = HDate(language="english", diaspora=diaspora)
         mydate.hdate = HebrewDate(year, Months.TISHREI, 1)
         tdelta = dt.timedelta((12 - mydate.gdate.weekday()) % 7)
         # Go to the next shabbat (unless shabbat falls on Rosh Hashana)

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -76,10 +76,10 @@ class TestHDate:
         with pytest.raises(ValueError):
             HDate().hdate = HebrewDate(5779, 10, 35)
 
-    @pytest.mark.parametrize("execution_number", list(range(10)))
-    def test_random_hdate(self, execution_number: int, rand_hdate: HDate) -> None:
+    @given(date=strategies.dates())
+    def test_random_hdate(self, date: dt.date) -> None:
         """Run multiple cases with random hdates."""
-        print(f"Run number {execution_number}")
+        rand_hdate = HDate(date)
         _hdate = HDate()
         _hdate.hdate = rand_hdate.hdate
         assert _hdate.hdate == rand_hdate.hdate
@@ -440,13 +440,12 @@ class TestSpecialDays:
             else:
                 assert len(date_under_test.holidays) == 0
 
-    def test_get_holiday_hanuka_3rd_tevet(self) -> None:
+    @given(year=strategies.integers(min_value=5000, max_value=6000))
+    def test_get_holiday_hanuka_3rd_tevet(self, year: int) -> None:
         """Test Chanuka falling on 3rd of Tevet."""
-        year = random.randint(5000, 6000)
         year_size = HebrewDate.year_size(year)
         myhdate = HDate(heb_date=HebrewDate(year, 4, 3))
-        print(year_size)
-        if year_size in [353, 383]:
+        if year_size in (353, 383):
             assert myhdate.holidays[0].name == "chanukah"
         else:
             assert len(myhdate.holidays) == 0
@@ -479,9 +478,9 @@ class TestSpecialDays:
             else:
                 assert myhdate.holidays[0].name == holiday
 
-    def test_get_tishrei_rosh_chodesh(self) -> None:
+    @given(year=strategies.integers(min_value=5000, max_value=6000))
+    def test_get_tishrei_rosh_chodesh(self, year: int) -> None:
         """30th of Tishrei should be Rosh Chodesh"""
-        year = random.randint(5000, 6000)
         myhdate = HDate(heb_date=HebrewDate(year, Months.TISHREI, 30))
         assert myhdate.holidays[0].name == "rosh_chodesh"
         myhdate = HDate(heb_date=HebrewDate(year, Months.TISHREI, 1))

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -8,7 +8,7 @@ from typing import Union
 import pytest
 
 from hdate import HDate, HebrewDate
-from hdate.htables import Months
+from hdate.hebrew_date import Months
 
 HEBREW_YEARS_INFO = {
     # year, dow rosh hashana, length, dow pesach

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -193,14 +193,14 @@ class TestSpecialDays:
         ((20, 1), "hol_hamoed_sukkot"),
         ((21, 1), "hoshana_raba"),
         ((22, 1), "shmini_atzeret"),
-        ((15, 7), "pesach"),
-        ((17, 7), "hol_hamoed_pesach"),
-        ((18, 7), "hol_hamoed_pesach"),
-        ((19, 7), "hol_hamoed_pesach"),
-        ((20, 7), "hol_hamoed_pesach"),
-        ((21, 7), "pesach_vii"),
-        ((5, 9), "erev_shavuot"),
-        ((6, 9), "shavuot"),
+        ((15, 9), "pesach"),
+        ((17, 9), "hol_hamoed_pesach"),
+        ((18, 9), "hol_hamoed_pesach"),
+        ((19, 9), "hol_hamoed_pesach"),
+        ((20, 9), "hol_hamoed_pesach"),
+        ((21, 9), "pesach_vii"),
+        ((5, 11), "erev_shavuot"),
+        ((6, 11), "shavuot"),
         ((25, 3), "chanukah"),
         ((26, 3), "chanukah"),
         ((27, 3), "chanukah"),
@@ -210,36 +210,36 @@ class TestSpecialDays:
         ((2, 4), "chanukah"),
         ((10, 4), "asara_btevet"),
         ((15, 5), "tu_bshvat"),
-        ((18, 8), "lag_bomer"),
-        ((15, 11), "tu_bav"),
+        ((18, 10), "lag_bomer"),
+        ((15, 13), "tu_bav"),
     ]
 
     DIASPORA_ISRAEL_HOLIDAYS = [
         # Date, holiday in Diaspora, holiday in Israel
         ((16, 1), "sukkot_ii", "hol_hamoed_sukkot"),
         ((23, 1), "simchat_torah", ""),
-        ((16, 7), "pesach_ii", "hol_hamoed_pesach"),
-        ((22, 7), "pesach_viii", ""),
-        ((7, 9), "shavuot_ii", ""),
+        ((16, 9), "pesach_ii", "hol_hamoed_pesach"),
+        ((22, 9), "pesach_viii", ""),
+        ((7, 11), "shavuot_ii", ""),
     ]
 
     MOVING_HOLIDAYS = [
         # Possible dates, name
         ([(3, 1), (4, 1)], "tzom_gedaliah"),
-        ([(17, 10), (18, 10)], "tzom_tammuz"),
-        ([(9, 11), (10, 11)], "tisha_bav"),
+        ([(17, 12), (18, 12)], "tzom_tammuz"),
+        ([(9, 13), (10, 13)], "tisha_bav"),
     ]
 
     NEW_HOLIDAYS = [
         # Possible dates, test year range, name
-        ([(26, 7), (27, 7), (28, 7)], (5719, 6500), "yom_hashoah"),
-        ([(3, 8), (4, 8), (5, 8)], (5709, 5763), "yom_haatzmaut"),
-        ([(3, 8), (4, 8), (5, 8), (6, 8)], (5764, 6500), "yom_haatzmaut"),
-        ([(2, 8), (3, 8), (4, 8)], (5709, 5763), "yom_hazikaron"),
-        ([(2, 8), (3, 8), (4, 8), (5, 8)], (5764, 6500), "yom_hazikaron"),
-        ([(28, 8)], (5728, 6500), "yom_yerushalayim"),
+        ([(26, 9), (27, 9), (28, 9)], (5719, 6500), "yom_hashoah"),
+        ([(3, 10), (4, 10), (5, 10)], (5709, 5763), "yom_haatzmaut"),
+        ([(3, 10), (4, 10), (5, 10), (6, 10)], (5764, 6500), "yom_haatzmaut"),
+        ([(2, 10), (3, 10), (4, 10)], (5709, 5763), "yom_hazikaron"),
+        ([(2, 10), (3, 10), (4, 10), (5, 10)], (5764, 6500), "yom_hazikaron"),
+        ([(28, 10)], (5728, 6500), "yom_yerushalayim"),
         ([(11, 2), (12, 2)], (5758, 6500), "rabin_memorial_day"),
-        ([(29, 10)], (5765, 6500), "zeev_zhabotinsky_day"),
+        ([(29, 12)], (5765, 6500), "zeev_zhabotinsky_day"),
         ([(30, 5)], (5734, 6500), ["family_day", "rosh_chodesh"]),
     ]
 
@@ -504,13 +504,13 @@ class TestSpecialDays:
         sivan = list(range(1, 5))
 
         for day in nissan:
-            rand_hdate.hdate = HebrewDate(rand_hdate.hdate.year, 7, day)
+            rand_hdate.hdate = HebrewDate(rand_hdate.hdate.year, Months.NISAN, day)
             assert rand_hdate.omer.total_days == day - 15
         for day in iyyar:
-            rand_hdate.hdate = HebrewDate(rand_hdate.hdate.year, 8, day)
+            rand_hdate.hdate = HebrewDate(rand_hdate.hdate.year, Months.IYYAR, day)
             assert rand_hdate.omer.total_days == day + 15
         for day in sivan:
-            rand_hdate.hdate = HebrewDate(rand_hdate.hdate.year, 9, day)
+            rand_hdate.hdate = HebrewDate(rand_hdate.hdate.year, Months.SIVAN, day)
             assert rand_hdate.omer.total_days == day + 44
 
     def test_daf_yomi(self) -> None:

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -487,17 +487,13 @@ class TestSpecialDays:
         myhdate = HDate(heb_date=HebrewDate(year, Months.TISHREI, 1))
         assert myhdate.holidays[0].name == "rosh_hashana_i"
 
-    @pytest.mark.parametrize("execution_number", list(range(10)))
-    def test_get_omer_day(self, execution_number: int, rand_hdate: HDate) -> None:
+    @given(date=strategies.dates())
+    def test_get_omer_day(self, date: dt.date) -> None:
         """Test value of the Omer."""
-        print(f"Test number {execution_number}")
-        if (
-            rand_hdate.hdate.month not in [Months.NISAN, Months.IYYAR, Months.SIVAN]
-            or rand_hdate.hdate.month == Months.NISAN
-            and rand_hdate.hdate.day < 16
-            or rand_hdate.hdate.month == Months.SIVAN
-            and rand_hdate.hdate.day > 5
-        ):
+        rand_hdate = HDate(date)
+        if rand_hdate.hdate < HebrewDate(
+            0, Months.NISAN, 16
+        ) or rand_hdate.hdate > HebrewDate(0, Months.SIVAN, 5):
             assert rand_hdate.omer.total_days == 0
 
         nissan = list(range(16, 30))

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -888,7 +888,9 @@ class TestHDateReading:
 
     @pytest.mark.parametrize("diaspora", [True, False])
     @given(year=strategies.integers(min_value=4000, max_value=6000))
-    def test_nitzavim_always_before_rosh_hashana(self, year: int, diaspora: bool) -> None:
+    def test_nitzavim_always_before_rosh_hashana(
+        self, year: int, diaspora: bool
+    ) -> None:
         """A property: Nitzavim alway falls before rosh hashana."""
         mydate = HDate(language="english", diaspora=diaspora)
         mydate.hdate = HebrewDate(year, Months.TISHREI, 1)
@@ -900,7 +902,9 @@ class TestHDateReading:
 
     @pytest.mark.parametrize("diaspora", [True, False])
     @given(year=strategies.integers(min_value=4000, max_value=6000))
-    def test_vayelech_or_haazinu_always_after_rosh_hashana(self, year: int, diaspora: bool) -> None:
+    def test_vayelech_or_haazinu_always_after_rosh_hashana(
+        self, year: int, diaspora: bool
+    ) -> None:
         """A property: Vayelech or Haazinu always falls after rosh hashana."""
         mydate = HDate(language="english", diaspora=diaspora)
         mydate.hdate = HebrewDate(year, Months.TISHREI, 1)

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -95,24 +95,24 @@ class TestHDate:
             rosh_hashana = HebrewDate(year)
             assert rosh_hashana.dow() == info[0]
 
-    def test_pesach_day_of_week(self, rand_hdate: HDate) -> None:
-        """ "Check tha Pesach DOW matches the given dates."""
+    def test_pesach_day_of_week(self) -> None:
+        """ "Check that Pesach DOW matches the given dates."""
         for year, info in list(HEBREW_YEARS_INFO.items()):
-            rand_hdate.hdate = HebrewDate(year, Months.NISAN, 15)
-            assert rand_hdate.dow == info[2]
-            assert rand_hdate.holidays[0].name == "pesach"
+            my_hdate = HDate(heb_date=HebrewDate(year, Months.NISAN, 15))
+            assert my_hdate.dow == info[2]
+            assert my_hdate.holidays[0].name == "pesach"
 
     UPCOMING_SHABBATOT = [
-        ((2018, 11, 30), (2018, 12, 1), (5779, 3, 22)),
-        ((2018, 12, 1), (2018, 12, 1), (5779, 3, 23)),
-        ((2018, 12, 2), (2018, 12, 8), (5779, 3, 24)),
-        ((2018, 12, 3), (2018, 12, 8), (5779, 3, 25)),
-        ((2018, 12, 4), (2018, 12, 8), (5779, 3, 26)),
-        ((2018, 12, 5), (2018, 12, 8), (5779, 3, 27)),
-        ((2018, 12, 6), (2018, 12, 8), (5779, 3, 28)),
-        ((2018, 12, 7), (2018, 12, 8), (5779, 3, 29)),
-        ((2018, 12, 8), (2018, 12, 8), (5779, 3, 30)),
-        ((2018, 12, 9), (2018, 12, 15), (5779, 4, 1)),
+        ((2018, 11, 30), (2018, 12, 1), (5779, Months.KISLEV, 22)),
+        ((2018, 12, 1), (2018, 12, 1), (5779, Months.KISLEV, 23)),
+        ((2018, 12, 2), (2018, 12, 8), (5779, Months.KISLEV, 24)),
+        ((2018, 12, 3), (2018, 12, 8), (5779, Months.KISLEV, 25)),
+        ((2018, 12, 4), (2018, 12, 8), (5779, Months.KISLEV, 26)),
+        ((2018, 12, 5), (2018, 12, 8), (5779, Months.KISLEV, 27)),
+        ((2018, 12, 6), (2018, 12, 8), (5779, Months.KISLEV, 28)),
+        ((2018, 12, 7), (2018, 12, 8), (5779, Months.KISLEV, 29)),
+        ((2018, 12, 8), (2018, 12, 8), (5779, Months.KISLEV, 30)),
+        ((2018, 12, 9), (2018, 12, 15), (5779, Months.TEVET, 1)),
     ]
 
     @pytest.mark.parametrize(

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -4,6 +4,7 @@ import datetime as dt
 
 import pytest
 from hypothesis import given, strategies
+from syrupy.assertion import SnapshotAssertion
 
 from hdate.hebrew_date import HebrewDate, Months
 
@@ -79,3 +80,23 @@ def test_hebrew_date_addition_with_no_year(d1: HebrewDate, d2: HebrewDate) -> No
     """Test HebrewDate addition and subtraction when there is no year."""
     diff = d2 - d1
     assert d1 + diff == d2
+
+
+def test_to_jdn_snapshot(snapshot: SnapshotAssertion) -> None:
+    """Test the to_jdn method."""
+    assert HebrewDate(5785, Months.TEVET, 5).to_jdn() == snapshot
+
+
+def test_from_jdn_snapshot(snapshot: SnapshotAssertion) -> None:
+    """Test the from_jdn method."""
+    assert HebrewDate.from_jdn(2451545) == snapshot
+
+
+def test_to_gdate_snapshot(snapshot: SnapshotAssertion) -> None:
+    """Test the to_gdate method."""
+    assert HebrewDate(5785, Months.TEVET, 5).to_gdate() == snapshot
+
+
+def test_from_gdate_snapshot(snapshot: SnapshotAssertion) -> None:
+    """Test the from_gdate method."""
+    assert HebrewDate.from_gdate(dt.date(2025, 1, 5)) == snapshot

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -113,15 +113,7 @@ def test_adar_compare_mode(
 def valid_hebrew_date(draw: strategies.DrawFn) -> HebrewDate:
     """Generate a valid Hebrew date."""
     year = draw(strategies.integers(min_value=MIN_YEAR, max_value=MAX_YEAR))
-
-    months = list(Months)
-    if HebrewDate(year).is_leap_year():
-        months.remove(Months.ADAR)
-    else:
-        months.remove(Months.ADAR_I)
-        months.remove(Months.ADAR_II)
-    month = draw(strategies.sampled_from(months))
-
+    month = draw(strategies.sampled_from(Months.in_year(year)))
     days = HebrewDate(year).days_in_month(month)
     day = draw(strategies.integers(min_value=1, max_value=days))
 

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -5,8 +5,7 @@ import datetime as dt
 import pytest
 from hypothesis import given, strategies
 
-from hdate.hebrew_date import HebrewDate
-from hdate.htables import Months
+from hdate.hebrew_date import HebrewDate, Months
 
 MIN_YEAR = 3762
 MAX_YEAR = 6000

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -3,7 +3,7 @@
 import datetime as dt
 
 import pytest
-from hypothesis import given, strategies
+from hypothesis import example, given, strategies
 from syrupy.assertion import SnapshotAssertion
 
 from hdate.hebrew_date import (
@@ -151,7 +151,6 @@ def test_relative_hebrew_date_comparisons(d1: HebrewDate, d2: HebrewDate) -> Non
     assert (d1 >= d2) == ((d1.month, d1.day) >= (d2.month, d2.day))
 
 
-@pytest.mark.xfail(reason="Needs support for leap years")
 @given(
     d1=valid_hebrew_date(),
     days=strategies.integers(min_value=-500, max_value=500),
@@ -163,8 +162,9 @@ def test_hebrew_date_addition(d1: HebrewDate, days: int) -> None:
     assert d2 - d1 == delta
 
 
-@pytest.mark.xfail(reason="Needs support for leap years")
+@pytest.mark.xfail(reason="Will fail if relative date does not exist in current year.")
 @given(d1=valid_hebrew_date(), d2=relative_hebrew_date())
+@example(d2=HebrewDate(0, Months.MARCHESHVAN, 30))
 def test_hebrew_date_addition_with_no_year(d1: HebrewDate, d2: HebrewDate) -> None:
     """Test HebrewDate addition and subtraction when there is no year."""
     diff = d2 - d1

--- a/tests/test_hebrew_date.py
+++ b/tests/test_hebrew_date.py
@@ -10,6 +10,7 @@ from hdate.hebrew_date import (
     CHANGING_MONTHS,
     LONG_MONTHS,
     SHORT_MONTHS,
+    ComparisonMode,
     HebrewDate,
     Months,
     is_leap_year,
@@ -62,6 +63,50 @@ def test_lists_of_months() -> None:
         Months.ELUL,
     }
     assert CHANGING_MONTHS == (Months.MARCHESHVAN, Months.KISLEV)
+
+
+def test_months_order() -> None:
+    """Test that the months are in the correct order."""
+    assert Months.TISHREI < Months.MARCHESHVAN < Months.KISLEV < Months.TEVET
+    assert Months.TEVET < Months.SHVAT < Months.ADAR < Months.NISAN < Months.IYYAR
+    assert Months.IYYAR < Months.SIVAN < Months.TAMMUZ < Months.AV < Months.ELUL
+    assert Months.SHVAT < Months.ADAR_I < Months.ADAR_II < Months.NISAN
+
+
+@pytest.mark.parametrize("order_type", ["calendar", "biblical"])
+@pytest.mark.parametrize("compare_mode", list(ComparisonMode))
+@pytest.mark.parametrize("month", list(Months))
+def test_compare_mode_eq(
+    order_type: str, compare_mode: ComparisonMode, month: Months
+) -> None:
+    """Test that the comparison mode works correctly."""
+    month.set_comparison_mode(compare_mode)
+    assert month.compare(month, order_type) == 0
+
+
+@pytest.mark.parametrize("compare_mode_1", list(ComparisonMode))
+@pytest.mark.parametrize("compare_mode_2", list(ComparisonMode))
+@given(
+    month_1=strategies.sampled_from(list(Months)),
+    month_2=strategies.sampled_from(list(Months)),
+)
+def test_adar_compare_mode(
+    compare_mode_1: ComparisonMode,
+    month_1: Months,
+    compare_mode_2: ComparisonMode,
+    month_2: Months,
+) -> None:
+    """Test ADAR using various comparison modes."""
+    compare_mode = compare_mode_1 | compare_mode_2
+    month_1.set_comparison_mode(compare_mode_1)
+    month_2.set_comparison_mode(compare_mode_2)
+    if (
+        month_1.value in compare_mode.equal_month_values
+        and month_2.value in compare_mode.equal_month_values
+    ) or (month_1.value == month_2.value):
+        assert month_1 == month_2
+    else:
+        assert month_1 != month_2
 
 
 @strategies.composite

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from hdate.htables import Months
+from hdate.hebrew_date import Months
 
 LANGUAGES = ["english", "french", "hebrew"]
 

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -70,7 +70,7 @@ class TestZmanim:
         this_date, other_date = dates
         this_zmanim = Zmanim(this_date).get_utc_sun_time_full()
         other_zmanim = Zmanim(other_date).get_utc_sun_time_full()
-        grace = 0 if not _ASTRAL else 14
+        grace = 0 if not _ASTRAL else 15
         for zman in this_zmanim:
             other = next(o for o in other_zmanim if o.name == zman.name)
             assert (

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 env_list = py{39,310,311,312,313}, lint
-passenv =
-    CI
 
 [testenv]
+passenv =
+    CI
+    GITHUB_*
 groups = test
 commands =
     pytest {posargs: --doctest-modules --cov=hdate --cov-report=term-missing tests}

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,12 @@
 env_list = py{39,310,311,312,313}, lint
 
 [testenv]
-groups = tests
+groups = test
 commands =
     pytest {posargs: --doctest-modules --cov=hdate --cov-report=term-missing -vv tests}
 
 [testenv:lint]
-groups = dev
+groups =
+    dev
+    test
 commands = pre-commit run --all

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ env_list = py{39,310,311,312,313}, lint
 [testenv]
 groups = test
 commands =
-    pytest {posargs: --doctest-modules --cov=hdate --cov-report=term-missing -vv tests}
+    pytest {posargs: -s --doctest-modules --cov=hdate --cov-report=term-missing tests}
 
 [testenv:lint]
 groups =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ env_list = py{39,310,311,312,313}, lint
 [testenv]
 groups = test
 commands =
-    pytest {posargs: -s --doctest-modules --cov=hdate --cov-report=term-missing tests}
+    pytest {posargs: --doctest-modules --cov=hdate --cov-report=term-missing tests}
 
 [testenv:lint]
 groups =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 env_list = py{39,310,311,312,313}, lint
+passenv =
+    CI
 
 [testenv]
 groups = test


### PR DESCRIPTION
# Description
Currently, the HebrewDate API isn't too clear regarding ADAR vs leap-ADARs when relating to relative dates (year == 0)
This PR addresses these discrepancies.

As such 4 modes of comparison exist:
- Strict
- Adar is considered Adar I
- Adar is considered Adar II
- Adar is considered any Adar (compare only)

When two dates are subtracted or compared, and one of them is a relative date, and one of them is a date in Adar, we will check the value of the leap comparison argument.

The leap comparison argument is used between both dates to decide the final comparison argument.

To do this as well as to simplify some of the code regarding months, we move some of the information to be part of the Months enum.

# Closes issue(s)

  Fixes: #<issue number>

# Changes included (select only one)

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backward-compatible)

# Checklist

- [ ] Code passes tox
