### PR TITLE
Streamline Zmanim API

### DIFF
--- a/hdate/tekufot.py
+++ b/hdate/tekufot.py
@@ -130,7 +130,7 @@ class Tekufot(TranslatorMixin):
             cheilat_geshamim_dt = self.get_tekufot()["Tishrei"] + dt.timedelta(days=59)
             time_end_of_day = Zmanim(
                 cheilat_geshamim_dt.date(), location=self.location
-            ).zmanim["first_stars"]
+            ).first_stars.local
             if cheilat_geshamim_dt < time_end_of_day:
                 # Normalize to date at midnight
                 cheilat_geshamim = cheilat_geshamim_dt.date()

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -9,6 +9,7 @@ import datetime as dt
 import logging
 import math
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import Optional, cast
 
 from hdate.date import HDate
@@ -81,18 +82,18 @@ class Zmanim(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
     def __str__(self) -> str:
         """Return a string representation of Zmanim in the selected language."""
         return "\n".join(
-            [f"{zman} - {zman.local.time()}" for _, zman in self.zmanim().items()]
+            [f"{zman} - {zman.local.time()}" for _, zman in self.zmanim.items()]
         )
 
     def __getattr__(self, name: str) -> Zman:
         """Return a specific Zman."""
-        if name in (zmanim := self.zmanim()):
+        if name in (zmanim := self.zmanim):
             return zmanim[name]
         raise AttributeError(f"{type(self).__name__} has no attribute {name}")
 
     def __dir__(self) -> list[str]:
         """Return a list of available attributes."""
-        return [*super().__dir__(), *self.zmanim().keys()]
+        return [*super().__dir__(), *self.zmanim.keys()]
 
     @property
     def candle_lighting(self) -> Optional[dt.datetime]:
@@ -293,6 +294,7 @@ class Zmanim(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
             )
         )
 
+    @cached_property
     def zmanim(self) -> dict[str, Zman]:
         """Return a list of Jewish times for the given location."""
         if (not _USE_ASTRAL) or (abs(self.location.latitude) > MAX_LATITUDE_ASTRAL):

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -209,7 +209,7 @@ class Zmanim(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
         the sky there.
 
         Algorithm from
-        http://www.srrb.noaa.gov/highlights/sunrise/calcdetails.html
+        https://gml.noaa.gov/grad/solcalc/solareqns.PDF
         The low accuracy solar position equations are used.
         These routines are based on Jean Meeus's book Astronomical Algorithms.
         """
@@ -222,7 +222,7 @@ class Zmanim(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
         eqtime = 0.0  # difference betwen sun noon and clock noon
         decl = 0.0  # sun declanation
         hour_angle = 0.0  # solar hour angle
-        sunrise_angle = math.pi * deg / 180.0  # sun angle at sunrise/set
+        sunrise_angle = math.radians(deg)  # sun angle at sunrise/set
 
         # get the day of year
         day_of_year = float(gday_of_year(self.date))
@@ -250,8 +250,7 @@ class Zmanim(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
             + 0.00148 * math.sin(3.0 * gama)
         )
 
-        # we use radians, ratio is 2pi/360
-        latitude = math.pi * self.location.latitude / 180.0
+        latitude = math.radians(self.location.latitude)
 
         # the sun real time diff from noon at sunset/rise in radians
         try:

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -35,8 +35,6 @@ class Zman(TranslatorMixin):
     minutes: float
     date: dt.date
     timezone: dt.tzinfo
-    utc: dt.datetime = dt.datetime.now()
-    local: dt.datetime = dt.datetime.now()
 
     def __post_init__(self) -> None:
         basetime = dt.datetime.combine(self.date, dt.time()).replace(

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -182,10 +182,6 @@ class Zmanim(TranslatorMixin):
         if self.havdalah is None:  # If there's no havdala, no need to check further
             return False
 
-        if (self.today.is_shabbat or self.today.is_yom_tov) and (
-            self.tomorrow.is_shabbat or self.tomorrow.is_yom_tov
-        ):
-            return False
         if (self.today.is_shabbat or self.today.is_yom_tov) and (_time > self.havdalah):
             return True
 

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -281,6 +281,7 @@ class Zmanim(TranslatorMixin):
         astral_observer = astral.Observer(
             latitude=self.location.latitude,
             longitude=self.location.longitude,
+            elevation=self.location.altitude,
         )
         return self._datetime_to_minutes_offest(
             astral.sun.time_of_transit(

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -182,7 +182,9 @@ class Zmanim(TranslatorMixin):
         if self.havdalah is None:  # If there's no havdala, no need to check further
             return False
 
-        if (self.today.is_shabbat or self.today.is_yom_tov) and (_time > self.havdalah):
+        if (self.today.is_shabbat or self.today.is_yom_tov) and (
+            _time >= self.havdalah
+        ):
             return True
 
         return False

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -281,7 +281,6 @@ class Zmanim(TranslatorMixin):
         astral_observer = astral.Observer(
             latitude=self.location.latitude,
             longitude=self.location.longitude,
-            elevation=self.location.altitude,
         )
         return self._datetime_to_minutes_offest(
             astral.sun.time_of_transit(

--- a/tests/__snapshots__/test_hdate_api.ambr
+++ b/tests/__snapshots__/test_hdate_api.ambr
@@ -1,0 +1,45 @@
+# serializer version: 1
+# name: TestZmanimAPI.test_readme_example_english[Petah Tikva]
+  '''
+  Alot HaShachar - 04:50:00
+  Talit & Tefilin's time - 05:16:00
+  Sunrise - 06:07:00
+  Shema EOT MG"A - 08:45:00
+  Shema EOT GR"A - 09:22:00
+  Tefila EOT MG"A - 10:03:20
+  Tefila EOT GR"A - 10:27:00
+  Midday - 12:40:00
+  Big Mincha - 13:09:30
+  Big Mincha 30 min - 13:10:00
+  Small Mincha - 16:24:30
+  Plag Mincha - 17:51:45
+  Sunset - 19:13:00
+  End of fast - 19:41:00
+  End of Shabbat - 19:51:00
+  Tset Hakochavim (18 minutes) - 19:32:30
+  Night by Rabbeinu Tam - 20:31:00
+  Midnight - 00:40:00
+  '''
+# ---
+# name: TestZmanimAPI.test_readme_example_hebrew[Petah Tikva]
+  '''
+  עלות השחר - 04:50:00
+  זמן טלית ותפילין - 05:16:00
+  הנץ החמה - 06:07:00
+  סוף זמן ק"ש מג"א - 08:45:00
+  סוף זמן ק"ש גר"א - 09:22:00
+  סוף זמן תפילה מג"א - 10:03:20
+  סוף זמן תפילה גר"א - 10:27:00
+  חצות היום - 12:40:00
+  מנחה גדולה - 13:09:30
+  מנחה גדולה 30 דק - 13:10:00
+  מנחה קטנה - 16:24:30
+  פלג המנחה - 17:51:45
+  שקיעה - 19:13:00
+  מוצאי צום - 19:41:00
+  מוצאי שבת - 19:51:00
+  צאת הכוכבים (18 דק) - 19:32:30
+  לילה לרבנו תם - 20:31:00
+  חצות הלילה - 00:40:00
+  '''
+# ---

--- a/tests/__snapshots__/test_hdate_api.ambr
+++ b/tests/__snapshots__/test_hdate_api.ambr
@@ -1,45 +1,45 @@
 # serializer version: 1
 # name: TestZmanimAPI.test_readme_example_english[Petah Tikva]
   '''
-  Alot HaShachar - 04:50:00
-  Talit & Tefilin's time - 05:16:00
-  Sunrise - 06:07:00
-  Shema EOT MG"A - 08:45:00
-  Shema EOT GR"A - 09:22:00
-  Tefila EOT MG"A - 10:03:20
-  Tefila EOT GR"A - 10:27:00
+  Alot HaShachar - 04:52:00
+  Talit & Tefilin's time - 05:18:00
+  Sunrise - 06:08:00
+  Shema EOT MG"A - 08:46:00
+  Shema EOT GR"A - 09:23:00
+  Tefila EOT MG"A - 10:04:00
+  Tefila EOT GR"A - 10:28:00
   Midday - 12:40:00
-  Big Mincha - 13:09:30
+  Big Mincha - 13:10:30
   Big Mincha 30 min - 13:10:00
-  Small Mincha - 16:24:30
-  Plag Mincha - 17:51:45
-  Sunset - 19:13:00
-  End of fast - 19:41:00
-  End of Shabbat - 19:51:00
-  Tset Hakochavim (18 minutes) - 19:32:30
-  Night by Rabbeinu Tam - 20:31:00
+  Small Mincha - 16:25:30
+  Plag Mincha - 17:50:45
+  Sunset - 19:12:00
+  End of fast - 19:40:00
+  End of Shabbat - 19:50:00
+  Tset Hakochavim (18 minutes) - 19:31:30
+  Night by Rabbeinu Tam - 20:30:00
   Midnight - 00:40:00
   '''
 # ---
 # name: TestZmanimAPI.test_readme_example_hebrew[Petah Tikva]
   '''
-  עלות השחר - 04:50:00
-  זמן טלית ותפילין - 05:16:00
-  הנץ החמה - 06:07:00
-  סוף זמן ק"ש מג"א - 08:45:00
-  סוף זמן ק"ש גר"א - 09:22:00
-  סוף זמן תפילה מג"א - 10:03:20
-  סוף זמן תפילה גר"א - 10:27:00
+  עלות השחר - 04:52:00
+  זמן טלית ותפילין - 05:18:00
+  הנץ החמה - 06:08:00
+  סוף זמן ק"ש מג"א - 08:46:00
+  סוף זמן ק"ש גר"א - 09:23:00
+  סוף זמן תפילה מג"א - 10:04:00
+  סוף זמן תפילה גר"א - 10:28:00
   חצות היום - 12:40:00
-  מנחה גדולה - 13:09:30
+  מנחה גדולה - 13:10:30
   מנחה גדולה 30 דק - 13:10:00
-  מנחה קטנה - 16:24:30
-  פלג המנחה - 17:51:45
-  שקיעה - 19:13:00
-  מוצאי צום - 19:41:00
-  מוצאי שבת - 19:51:00
-  צאת הכוכבים (18 דק) - 19:32:30
-  לילה לרבנו תם - 20:31:00
+  מנחה קטנה - 16:25:30
+  פלג המנחה - 17:50:45
+  שקיעה - 19:12:00
+  מוצאי צום - 19:40:00
+  מוצאי שבת - 19:50:00
+  צאת הכוכבים (18 דק) - 19:31:30
+  לילה לרבנו תם - 20:30:00
   חצות הלילה - 00:40:00
   '''
 # ---

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -489,6 +489,7 @@ class TestSpecialDays:
         assert myhdate.holidays[0].name == "rosh_hashana_i"
 
     @given(date=strategies.dates())
+    @settings(deadline=None)
     def test_get_omer_day(self, date: dt.date) -> None:
         """Test value of the Omer."""
         rand_hdate = HDate(date)

--- a/tests/test_hdate_api.py
+++ b/tests/test_hdate_api.py
@@ -8,6 +8,7 @@ import sys
 from typing import cast
 
 import pytest
+import syrupy
 from _pytest.capture import CaptureFixture
 
 from hdate import HDate, Location, Zmanim
@@ -68,65 +69,23 @@ class TestZmanimAPI:
 
     @pytest.mark.parametrize("location", ["Petah Tikva"], indirect=True)
     def test_readme_example_hebrew(
-        self, capsys: CaptureFixture[str], location: Location
+        self, location: Location, snapshot: syrupy.assertion.SnapshotAssertion
     ) -> None:
         """Test for hebrew."""
         zman = Zmanim(date=dt.date(2016, 4, 18), location=location)
-        print(zman)
-        captured = capsys.readouterr()
         if not _ASTRAL:
             return
-        assert (
-            captured.out == "עלות השחר - 04:52:00\n"
-            "זמן טלית ותפילין - 05:18:00\n"
-            "הנץ החמה - 06:08:00\n"
-            'סוף זמן ק"ש מג"א - 08:46:00\n'
-            'סוף זמן ק"ש גר"א - 09:23:00\n'
-            'סוף זמן תפילה מג"א - 10:04:00\n'
-            'סוף זמן תפילה גר"א - 10:28:00\n'
-            "חצות היום - 12:40:00\n"
-            "מנחה גדולה - 13:10:30\n"
-            "מנחה גדולה 30 דק - 13:10:00\n"
-            "מנחה קטנה - 16:25:30\n"
-            "פלג המנחה - 17:50:45\n"
-            "שקיעה - 19:12:00\n"
-            "מוצאי צום - 19:40:00\n"
-            "מוצאי שבת - 19:50:00\n"
-            "צאת הכוכבים (18 דק) - 19:31:30\n"
-            "לילה לרבנו תם - 20:30:00\n"
-            "חצות הלילה - 00:40:00\n"
-        )
+        assert str(zman) == snapshot
 
     @pytest.mark.parametrize("location", ["Petah Tikva"], indirect=True)
     def test_readme_example_english(
-        self, capsys: CaptureFixture[str], location: Location
+        self, location: Location, snapshot: syrupy.assertion.SnapshotAssertion
     ) -> None:
         """Test for english."""
         zman = Zmanim(date=dt.date(2016, 4, 18), location=location, language="english")
-        print(zman)
-        captured = capsys.readouterr()
         if not _ASTRAL:
             return
-        assert (
-            captured.out == "Alot HaShachar - 04:52:00\n"
-            "Talit & Tefilin's time - 05:18:00\n"
-            "Sunrise - 06:08:00\n"
-            'Shema EOT MG"A - 08:46:00\n'
-            'Shema EOT GR"A - 09:23:00\n'
-            'Tefila EOT MG"A - 10:04:00\n'
-            'Tefila EOT GR"A - 10:28:00\n'
-            "Midday - 12:40:00\n"
-            "Big Mincha - 13:10:30\n"
-            "Big Mincha 30 min - 13:10:00\n"
-            "Small Mincha - 16:25:30\n"
-            "Plag Mincha - 17:50:45\n"
-            "Sunset - 19:12:00\n"
-            "End of fast - 19:40:00\n"
-            "End of Shabbat - 19:50:00\n"
-            "Tset Hakochavim (18 minutes) - 19:31:30\n"
-            "Night by Rabbeinu Tam - 20:30:00\n"
-            "Midnight - 00:40:00\n"
-        )
+        assert str(zman) == snapshot
 
     @pytest.mark.parametrize("location", ["Petah Tikva"], indirect=True)
     def test_issur_melacha_weekday(self, location: Location) -> None:

--- a/tests/test_hdate_api.py
+++ b/tests/test_hdate_api.py
@@ -40,11 +40,6 @@ class TestHDateAPI:
         test_date = dt.datetime(2018, 11, 2)
         assert HDate(test_date).hebrew_date == 'כ"ד מרחשוון ה\' תשע"ט'
         assert HDate(test_date, language="english").hebrew_date == "24 Marcheshvan 5779"
-
-    def test_get_hebrew_date_multilanguage(self) -> None:
-        """Print the hebrew date."""
-        test_date = dt.datetime(2018, 11, 2)
-        assert HDate(test_date).hebrew_date == 'כ"ד מרחשוון ה\' תשע"ט'
         assert HDate(test_date, language="french").hebrew_date == "24 Heshvan 5779"
 
     def test_get_upcoming_parasha(self) -> None:
@@ -58,11 +53,6 @@ class TestHDateAPI:
         test_date = dt.datetime(2018, 9, 30)
         assert HDate(test_date).parasha == "וזאת הברכה"
         assert HDate(test_date, language="english").parasha == "Vezot Habracha"
-
-    def test_get_upcoming_parasha_vezot_habracha_french(self) -> None:
-        """Check that the upcoming parasha is correct for vezot habracha in french."""
-        test_date = dt.datetime(2018, 9, 30)
-        assert HDate(test_date).parasha == "וזאת הברכה"
         assert HDate(test_date, language="french").parasha == "Vezot Haberakha"
 
     def test_get_holiday_description(self) -> None:

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -225,12 +225,10 @@ def test_candle_lighting_erev_shabbat_is_yom_tov(location: Location) -> None:
 
 
 @given(name=strategies.text().filter(lambda s: s not in dir(Zmanim)))
-@pytest.mark.parametrize("location", ["New York"], indirect=True)
-def test_non_existing_attribute(name: str, location: Location) -> None:
+def test_non_existing_attribute(name: str) -> None:
     """Test trying to access a Zmanim attribute that isn't in the class."""
     with pytest.raises(AttributeError):
-        zmanim = Zmanim(date=dt.date.today(), location=location)
-        assert getattr(zmanim, name) is None
+        assert getattr(Zmanim, name) is None
 
 
 def test_attributes_in_dir() -> None:

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -228,7 +228,8 @@ def test_candle_lighting_erev_shabbat_is_yom_tov(location: Location) -> None:
 def test_non_existing_attribute(name: str) -> None:
     """Test trying to access a Zmanim attribute that isn't in the class."""
     with pytest.raises(AttributeError):
-        assert getattr(Zmanim, name) is None
+        z = Zmanim()
+        assert z.__getattr__(name) is None  # pylint: disable=unnecessary-dunder-call
 
 
 def test_attributes_in_dir() -> None:

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -52,11 +52,11 @@ def test_bad_date() -> None:
 def test_same_doy_is_equal(this_date: dt.date, year_diff: int) -> None:
     """Test two doy to be equal."""
     other_date = dt.date(year_diff + this_date.year, this_date.month, this_date.day)
-    this_zmanim = Zmanim(this_date).get_utc_sun_time_full()
-    other_zmanim = Zmanim(other_date).get_utc_sun_time_full()
+    this_zmanim = Zmanim(this_date).zmanim()
+    other_zmanim = Zmanim(other_date).zmanim()
     grace = 10
-    for zman in this_zmanim:
-        other = next(o for o in other_zmanim if o.name == zman.name)
+    for name, zman in this_zmanim.items():
+        other = other_zmanim[name]
         assert zman.minutes - grace <= other.minutes <= zman.minutes + grace, zman.name
 
 
@@ -69,7 +69,7 @@ def test_extreme_zmanim(location: Location, result: dt.time) -> None:
     """Test that Zmanim north to 50 degrees latitude is correct."""
     day = dt.date(2024, 6, 18)
     compare_times(
-        Zmanim(date=day, location=location).zmanim["sunset"].time(), result, grace=5
+        Zmanim(date=day, location=location).sunset.local.time(), result, grace=5
     )
 
 

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -46,11 +46,13 @@ def test_bad_date() -> None:
 
 
 @given(
-    this_date=strategies.dates(max_value=dt.date(3000, 1, 1)),
+    this_date=strategies.dates(max_value=dt.date(3000, 1, 1)).filter(
+        lambda d: not (d.month == 2 and d.day == 29)
+    ),
     year_diff=strategies.integers(min_value=0, max_value=200),
 )
 def test_same_doy_is_equal(this_date: dt.date, year_diff: int) -> None:
-    """Test two doy to be equal."""
+    """Test two doy to have equal zmanim."""
     other_date = dt.date(year_diff + this_date.year, this_date.month, this_date.day)
     this_zmanim = Zmanim(this_date).zmanim
     other_zmanim = Zmanim(other_date).zmanim

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -52,8 +52,8 @@ def test_bad_date() -> None:
 def test_same_doy_is_equal(this_date: dt.date, year_diff: int) -> None:
     """Test two doy to be equal."""
     other_date = dt.date(year_diff + this_date.year, this_date.month, this_date.day)
-    this_zmanim = Zmanim(this_date).zmanim()
-    other_zmanim = Zmanim(other_date).zmanim()
+    this_zmanim = Zmanim(this_date).zmanim
+    other_zmanim = Zmanim(other_date).zmanim
     grace = 10
     for name, zman in this_zmanim.items():
         other = other_zmanim[name]

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -222,3 +222,18 @@ def test_candle_lighting_erev_shabbat_is_yom_tov(location: Location) -> None:
         )
     zman = Zmanim(date=day, location=location, candle_lighting_offset=18)
     assert zman.candle_lighting == actual_candle_lighting
+
+
+@given(name=strategies.text().filter(lambda s: s not in dir(Zmanim)))
+@pytest.mark.parametrize("location", ["New York"], indirect=True)
+def test_non_existing_attribute(name: str, location: Location) -> None:
+    """Test trying to access a Zmanim attribute that isn't in the class."""
+    with pytest.raises(AttributeError):
+        zmanim = Zmanim(date=dt.date.today(), location=location)
+        assert getattr(zmanim, name) is None
+
+
+def test_attributes_in_dir() -> None:
+    """Test that Zmanim attributes are in the dir."""
+    keys = {"alot_hashachar", "sunrise", "plag_mincha", "sunset", "three_stars"}
+    assert keys.issubset(set(dir(Zmanim())))


### PR DESCRIPTION
### **User description**
# Description

# Closes issue(s)

  Fixes: #97 (adds the fix that was done to Python 2 branch in #102)

# Changes included (select only one)

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible)

# Checklist

- [ ] Code passes tox


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored `Zmanim` API to use `__getattr__` for dynamic attribute access.

- Replaced `zmanim` property with a dictionary-based implementation.

- Simplified and clarified time-related attribute names and logic.

- Updated tests to align with the refactored `Zmanim` API.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tekufot.py</strong><dd><code>Refactor access to `first_stars` attribute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hdate/tekufot.py

<li>Updated access to <code>first_stars</code> using <code>local</code> attribute.<br> <li> Simplified logic for determining <code>cheilat_geshamim</code> date.


</details>


  </td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/176/files#diff-431cff1cdbbd9dfa435df6d6dc7a9f3b8eeff3b0353025fea6188adfe6560258">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zmanim.py</strong><dd><code>Refactor Zmanim class for dynamic attribute access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hdate/zmanim.py

<li>Introduced <code>__getattr__</code> for dynamic Zmanim attribute access.<br> <li> Replaced <code>zmanim</code> property with a dictionary-based implementation.<br> <li> Renamed <code>utc_zman</code> and <code>local_zman</code> to <code>utc</code> and <code>local</code>.<br> <li> Removed redundant <code>gday_of_year</code> method and inlined it.


</details>


  </td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/176/files#diff-89e8de55c95c9c0b90901f04831894c6c061c61df9d24e1b679623459b3d453f">+46/-45</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_zmanim.py</strong><dd><code>Update tests for refactored Zmanim API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_zmanim.py

<li>Updated tests to use new <code>zmanim</code> dictionary-based API.<br> <li> Adjusted test logic to align with refactored attribute names.


</details>


  </td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/176/files#diff-1be10eef83069d604ba1e19f9e605d6c854c7b86fef472282631acb1eef79b99">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information