### PR TITLE
Add diaspora argument to get_all_holiday_names

### DIFF
--- a/hdate/holidays.py
+++ b/hdate/holidays.py
@@ -177,20 +177,6 @@ class HolidayDatabase:
         return set(result)
 
 
-def correct_adar() -> Callable[[HebrewDate], Union[bool, Callable[[], bool]]]:
-    """
-    Return a lambda function.
-
-    Lambda checks that the value of the month returned is correct depending on whether
-    it's a leap year.
-    """
-    return lambda x: (
-        (x.month not in [Months.ADAR, Months.ADAR_I, Months.ADAR_II])
-        or (x.month == Months.ADAR and not x.is_leap_year())
-        or (x.month in (Months.ADAR_I, Months.ADAR_II) and x.is_leap_year())
-    )
-
-
 def move_if_not_on_dow(
     original: int, replacement: int, dow_not_orig: Weekday, dow_replacement: Weekday
 ) -> Callable[[HebrewDate], bool]:
@@ -268,22 +254,17 @@ HOLIDAYS = (
         HolidayTypes.FAST_DAY,
         "taanit_esther",
         ((Months.ADAR, Months.ADAR_II), (11, 13)),
-        [
-            correct_adar(),
-            move_if_not_on_dow(13, 11, Weekday.SATURDAY, Weekday.THURSDAY),
-        ],
+        [move_if_not_on_dow(13, 11, Weekday.SATURDAY, Weekday.THURSDAY)],
     ),
     Holiday(
         HolidayTypes.MELACHA_PERMITTED_HOLIDAY,
         "purim",
         ((Months.ADAR, Months.ADAR_II), 14),
-        [correct_adar()],
     ),
     Holiday(
         HolidayTypes.MELACHA_PERMITTED_HOLIDAY,
         "shushan_purim",
         ((Months.ADAR, Months.ADAR_II), 15),
-        [correct_adar()],
     ),
     Holiday(HolidayTypes.EREV_YOM_TOV, "erev_pesach", (Months.NISAN, 14)),
     Holiday(HolidayTypes.YOM_TOV, "pesach", (Months.NISAN, 15)),
@@ -389,7 +370,7 @@ HOLIDAYS = (
         HolidayTypes.MEMORIAL_DAY,
         "memorial_day_unknown",
         ((Months.ADAR, Months.ADAR_II), 7),
-        [correct_adar()],
+        [],
         "ISRAEL",
     ),
     Holiday(
@@ -413,13 +394,9 @@ HOLIDAYS = (
         HolidayTypes.ROSH_CHODESH,
         "rosh_chodesh",
         (tuple(set(Months) - {Months.TISHREI}), 1),
-        [correct_adar()],
     ),
     Holiday(
-        HolidayTypes.ROSH_CHODESH,
-        "rosh_chodesh",
-        (LONG_MONTHS + CHANGING_MONTHS, 30),
-        [correct_adar()],
+        HolidayTypes.ROSH_CHODESH, "rosh_chodesh", (LONG_MONTHS + CHANGING_MONTHS, 30)
     ),
 )
 

--- a/hdate/holidays.py
+++ b/hdate/holidays.py
@@ -157,24 +157,24 @@ class HolidayDatabase:
         return next_date.replace(year=date.year)
 
     @classmethod
-    def get_all_holiday_names(cls, language: str) -> set[str]:
+    def get_all_holiday_names(cls, language: str, diaspora: bool) -> list[str]:
         """Return all the holiday names in a given language."""
 
-        result = []
-        for holiday_list in [
-            cls._diaspora_holidays,
-            cls._israel_holidays,
-            cls._all_holidays,
-        ]:
-            for holidays in holiday_list.values():
-                holiday_names = {holiday.name for holiday in holidays}
-                if {"yom_haatzmaut", "yom_hazikaron"} == holiday_names:
-                    continue
-                for holiday in holidays:
-                    holiday.set_language(language)
-                holiday_strs = sorted(set(str(holiday) for holiday in holidays))
-                result.append(", ".join(holiday_strs))
-        return set(result)
+        local = cls._diaspora_holidays if diaspora else cls._israel_holidays
+        holiday_list = {
+            date: local[date] + cls._all_holidays[date]
+            for date in local.keys() | cls._all_holidays.keys()
+        }
+        result = {""}  # Empty string for case of no holiday
+        for holidays in holiday_list.values():
+            holiday_names = {holiday.name for holiday in holidays}
+            if {"yom_haatzmaut", "yom_hazikaron"} == holiday_names:
+                continue
+            for holiday in holidays:
+                holiday.set_language(language)
+            holiday_strs = sorted(set(str(holiday) for holiday in holidays))
+            result.add(", ".join(holiday_strs))
+        return list(sorted(result))
 
 
 def move_if_not_on_dow(

--- a/hdate/holidays.py
+++ b/hdate/holidays.py
@@ -157,7 +157,7 @@ class HolidayDatabase:
         return next_date.replace(year=date.year)
 
     @classmethod
-    def get_all_holiday_names(cls, language: str, diaspora: bool) -> list[str]:
+    def get_all_names(cls, language: str, diaspora: bool) -> list[str]:
         """Return all the holiday names in a given language."""
 
         local = cls._diaspora_holidays if diaspora else cls._israel_holidays

--- a/hdate/translations.py
+++ b/hdate/translations.py
@@ -64,7 +64,6 @@ TRANSLATIONS = {
             "niddah": "Niddah",
         },
         "Holiday": {
-            "none": "",
             "erev_rosh_hashana": "Erev Rosh Hashana",
             "rosh_hashana_i": "Rosh Hashana I",
             "rosh_hashana_ii": "Rosh Hashana II",
@@ -281,7 +280,6 @@ TRANSLATIONS = {
             "niddah": "Nida",
         },
         "Holiday": {
-            "none": "",
             "erev_rosh_hashana": "Veille de Rosh Hashana",
             "rosh_hashana_i": "Rosh Hashana I",
             "rosh_hashana_ii": "Rosh Hashana II",
@@ -498,7 +496,6 @@ TRANSLATIONS = {
             "niddah": "נדה",
         },
         "Holiday": {
-            "none": "",
             "erev_rosh_hashana": "ערב ראש השנה",
             "rosh_hashana_i": "א' ראש השנה",
             "rosh_hashana_ii": "ב' ראש השנה",

--- a/hdate/translations/en.json
+++ b/hdate/translations/en.json
@@ -55,7 +55,6 @@
         "niddah": "Niddah"
     },
     "Holiday": {
-        "none": "",
         "erev_rosh_hashana": "Erev Rosh Hashana",
         "rosh_hashana_i": "Rosh Hashana I",
         "rosh_hashana_ii": "Rosh Hashana II",

--- a/hdate/translations/fr.json
+++ b/hdate/translations/fr.json
@@ -55,7 +55,6 @@
         "niddah": "Nida"
     },
     "Holiday": {
-        "none": "",
         "erev_rosh_hashana": "Veille de Rosh Hashana",
         "rosh_hashana_i": "Rosh Hashana I",
         "rosh_hashana_ii": "Rosh Hashana II",

--- a/hdate/translations/he.json
+++ b/hdate/translations/he.json
@@ -55,7 +55,6 @@
         "niddah": "נדה"
     },
     "Holiday": {
-        "none": "",
         "erev_rosh_hashana": "ערב ראש השנה",
         "rosh_hashana_i": "א' ראש השנה",
         "rosh_hashana_ii": "ב' ראש השנה",

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -281,7 +281,7 @@ def test_get_tishrei_rosh_chodesh(year: int) -> None:
 @pytest.mark.parametrize("diaspora", [True, False])
 @pytest.mark.parametrize("language", ["english", "french", "hebrew"])
 def test_get_all_holidays(language: str, diaspora: bool) -> None:
-    """Helper method to get all the holiday descriptions in the specified language."""
+    """Test the method to get all the holiday descriptions in a specified language."""
 
     def holiday_name(holiday: Holiday, language: str) -> str:
         holiday.set_language(language)
@@ -305,22 +305,20 @@ def test_get_all_holidays(language: str, diaspora: bool) -> None:
         },
     }
     israel_diaspora = ("ISRAEL", "") if not diaspora else ("DIASPORA", "")
-    holidays_list = {
+    holidays = {
         holiday_name(h, language)
         for h in HOLIDAYS
         if h.israel_diaspora in israel_diaspora
     } | doubles[language][""]
     if not diaspora:
-        holidays_list -= {
+        holidays -= {
             _name
             for entry in doubles[language]["ISRAEL"]
             for name in entry.split(",")
             if (_name := name.strip())
             not in ("Rosh Hodesh", "Rosh Chodesh", "ראש חודש")
         }
-        holidays_list.update(doubles[language]["ISRAEL"])
-    holidays_list.add("")
+        holidays.update(doubles[language]["ISRAEL"])
+    holidays.add("")
 
-    assert HolidayDatabase.get_all_holiday_names(language, diaspora) == list(
-        sorted(holidays_list)
-    )
+    assert HolidayDatabase.get_all_names(language, diaspora) == list(sorted(holidays))

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -9,7 +9,7 @@ from hypothesis import given, settings, strategies
 
 from hdate import HDate, HebrewDate
 from hdate.hebrew_date import Months
-from hdate.holidays import HOLIDAYS, Holiday, HolidayDatabase
+from hdate.holidays import HolidayDatabase
 
 
 # Test against both a leap year and non-leap year
@@ -278,47 +278,35 @@ def test_get_tishrei_rosh_chodesh(year: int) -> None:
     assert myhdate.holidays[0].name == "rosh_hashana_i"
 
 
-@pytest.mark.parametrize("diaspora", [True, False])
+@pytest.mark.parametrize("diaspora", ["ISRAEL", "DIASPORA"])
 @pytest.mark.parametrize("language", ["english", "french", "hebrew"])
-def test_get_all_holidays(language: str, diaspora: bool) -> None:
+def test_get_all_holidays(language: str, diaspora: str) -> None:
     """Test the method to get all the holiday descriptions in a specified language."""
 
-    def holiday_name(holiday: Holiday, language: str) -> str:
-        holiday.set_language(language)
-        return str(holiday)
+    _diaspora = diaspora == "DIASPORA"
+    names = HolidayDatabase.get_all_names(language, _diaspora)
 
-    doubles = {
+    expected = {
         "french": {
+            "DIASPORA": {"Souccot II", "Pessah II"},
             "ISRAEL": {
                 "Fête de la Famille, Rosh Hodesh",
                 "Shemini Atseret, Simhat Torah",
             },
-            "": {"Hanoukka, Rosh Hodesh"},
+            "": {"Yom Kippour", "Hanoukka, Rosh Hodesh", "Pourim", "Pessah"},
         },
         "hebrew": {
+            "DIASPORA": {"שני של סוכות", "שני של פסח"},
             "ISRAEL": {"יום המשפחה, ראש חודש", "שמחת תורה, שמיני עצרת"},
-            "": {"חנוכה, ראש חודש"},
+            "": {"יום הכפורים", "חנוכה, ראש חודש", "פורים", "פסח"},
         },
         "english": {
+            "DIASPORA": {"Sukkot II", "Pesach II"},
             "ISRAEL": {"Family Day, Rosh Chodesh", "Shmini Atzeret, Simchat Torah"},
-            "": {"Chanukah, Rosh Chodesh"},
+            "": {"Yom Kippur", "Chanukah, Rosh Chodesh", "Purim", "Pesach"},
         },
     }
-    israel_diaspora = ("ISRAEL", "") if not diaspora else ("DIASPORA", "")
-    holidays = {
-        holiday_name(h, language)
-        for h in HOLIDAYS
-        if h.israel_diaspora in israel_diaspora
-    } | doubles[language][""]
-    if not diaspora:
-        holidays -= {
-            _name
-            for entry in doubles[language]["ISRAEL"]
-            for name in entry.split(",")
-            if (_name := name.strip())
-            not in ("Rosh Hodesh", "Rosh Chodesh", "ראש חודש")
-        }
-        holidays.update(doubles[language]["ISRAEL"])
-    holidays.add("")
-
-    assert HolidayDatabase.get_all_names(language, diaspora) == list(sorted(holidays))
+    fake = {"Non-existing Holiday", "Foo", "Bar"}
+    assert all(entry in names for entry in expected[language][""])
+    assert all(entry in names for entry in expected[language][diaspora])
+    assert all(item not in names for item in fake)


### PR DESCRIPTION
### **User description**
# Description
Also add an empty string to allow home assistant to compare the list of returned values easily.

# Closes issue(s)

  Fixes: #189

# Changes included (select only one)

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible)

# Checklist

- [ ] Code passes tox


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Updated `get_all_holiday_names` to include diaspora argument.

- Added empty string for days with no holidays.

- Removed unused `correct_adar` method and its references.

- Enhanced test coverage for `get_all_holiday_names` with diaspora and language parameters.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>holidays.py</strong><dd><code>Refactor and enhance `get_all_holiday_names` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hdate/holidays.py

<li>Modified <code>get_all_holiday_names</code> to accept a <code>diaspora</code> argument.<br> <li> Added empty string to holiday names for no-holiday days.<br> <li> Removed <code>correct_adar</code> method and its references.<br> <li> Adjusted holiday definitions to remove <code>correct_adar</code> dependency.


</details>


  </td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/191/files#diff-728ab9ad49daf819af84ede10569bb61c8a4acdbc07cbdb3bf6feff0487c9923">+19/-42</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_holidays.py</strong><dd><code>Add and update tests for `get_all_holiday_names`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_holidays.py

<li>Added tests for <code>get_all_holiday_names</code> with <code>diaspora</code> and language <br>parameters.<br> <li> Updated test logic to validate new behavior of <code>get_all_holiday_names</code>.<br> <li> Included edge cases for empty string and holiday combinations.


</details>


  </td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/191/files#diff-7de1e6ae260f3898f3274b1f1d72ef9a9f98fd785e9253a022fe88cd524003c0">+37/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>