### PR TITLE
Type language as literal for actual values

### DIFF
--- a/hdate/date.py
+++ b/hdate/date.py
@@ -17,7 +17,7 @@ from hdate.holidays import Holiday, HolidayDatabase, HolidayTypes
 from hdate.omer import Omer
 from hdate.parasha import Parasha, ParashaDatabase
 from hdate.tekufot import Nusachim, Tekufot
-from hdate.translator import TranslatorMixin
+from hdate.translator import Language, TranslatorMixin
 
 
 class HDate(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
@@ -31,7 +31,7 @@ class HDate(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
         self,
         date: Union[dt.date, HebrewDate] = dt.date.today(),
         diaspora: bool = False,
-        language: str = "hebrew",
+        language: Language = "hebrew",
         nusach: Nusachim = "sephardi",
     ) -> None:
         """Initialize the HDate object."""

--- a/hdate/holidays.py
+++ b/hdate/holidays.py
@@ -11,7 +11,7 @@ from itertools import product
 from typing import Callable, ClassVar, Iterable, Literal, Optional, Union
 
 from hdate.hebrew_date import CHANGING_MONTHS, LONG_MONTHS, HebrewDate, Months, Weekday
-from hdate.translator import TranslatorMixin
+from hdate.translator import Language, TranslatorMixin
 
 
 class HolidayTypes(Enum):
@@ -157,7 +157,7 @@ class HolidayDatabase:
         return next_date.replace(year=date.year)
 
     @classmethod
-    def get_all_names(cls, language: str, diaspora: bool) -> list[str]:
+    def get_all_names(cls, language: Language, diaspora: bool) -> list[str]:
         """Return all the holiday names in a given language."""
 
         local = cls._diaspora_holidays if diaspora else cls._israel_holidays

--- a/hdate/omer.py
+++ b/hdate/omer.py
@@ -9,7 +9,7 @@ from num2words import lang_HE, num2words
 
 from hdate.gematria import hebrew_number
 from hdate.hebrew_date import HebrewDate, Months
-from hdate.translator import TranslatorMixin
+from hdate.translator import Language, TranslatorMixin
 
 
 class Nusach(Enum):
@@ -31,7 +31,7 @@ class Omer(TranslatorMixin):
     week: int = 0
 
     nusach: Nusach = Nusach.SFARAD
-    language: str = "hebrew"
+    language: Language = "hebrew"
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/hdate/tekufot.py
+++ b/hdate/tekufot.py
@@ -17,7 +17,7 @@ from enum import Enum
 from typing import Literal
 
 from hdate.hebrew_date import HebrewDate, Months
-from hdate.translator import TranslatorMixin
+from hdate.translator import Language, TranslatorMixin
 
 
 class Gevurot(TranslatorMixin, Enum):
@@ -51,7 +51,7 @@ class Tekufot(TranslatorMixin):
     date: dt.date = field(default_factory=dt.date.today)
     diaspora: bool = False
     tradition: Nusachim = "sephardi"
-    language: str = "english"
+    language: Language = "english"
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/hdate/translator.py
+++ b/hdate/translator.py
@@ -7,11 +7,13 @@ based on the language specified.
 import logging
 import sys
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from hdate.translations import TRANSLATIONS
 
 _LOGGER = logging.getLogger(__name__)
+
+Language = Literal["english", "french", "hebrew"]
 
 
 class TranslatorMixin:
@@ -21,7 +23,7 @@ class TranslatorMixin:
     specified and the class name.
     """
 
-    _language: str = "english"
+    _language: Language = "english"
     _translations: dict[str, str] = {}
 
     def __init__(self, *args: Any, **kwargs: dict[str, Any]) -> None:
@@ -72,7 +74,7 @@ class TranslatorMixin:
             value = key
         return value
 
-    def set_language(self, language: str) -> None:
+    def set_language(self, language: Language) -> None:
         """Set the language for the translator."""
         object.__setattr__(self, "_language", language)
         self.load_translations()

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -14,7 +14,7 @@ from typing import Optional, cast
 
 from hdate.date import HDate
 from hdate.location import Location
-from hdate.translator import TranslatorMixin
+from hdate.translator import Language, TranslatorMixin
 
 try:
     import astral
@@ -60,7 +60,7 @@ class Zmanim(TranslatorMixin):
 
     date: dt.date = field(default_factory=dt.date.today)
     location: Location = field(default_factory=Location)
-    language: str = "hebrew"
+    language: Language = "hebrew"
     candle_lighting_offset: int = 18
     havdalah_offset: int = 0
 

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -10,6 +10,7 @@ from hypothesis import given, settings, strategies
 from hdate import HDate, HebrewDate
 from hdate.hebrew_date import Months
 from hdate.holidays import HolidayDatabase
+from hdate.translator import Language
 
 
 # Test against both a leap year and non-leap year
@@ -280,7 +281,7 @@ def test_get_tishrei_rosh_chodesh(year: int) -> None:
 
 @pytest.mark.parametrize("diaspora", ["ISRAEL", "DIASPORA"])
 @pytest.mark.parametrize("language", ["english", "french", "hebrew"])
-def test_get_all_holidays(language: str, diaspora: str) -> None:
+def test_get_all_holidays(language: Language, diaspora: str) -> None:
     """Test the method to get all the holiday descriptions in a specified language."""
 
     _diaspora = diaspora == "DIASPORA"

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 import random
+import typing
 from collections import defaultdict
 
 import pytest
@@ -280,7 +281,7 @@ def test_get_tishrei_rosh_chodesh(year: int) -> None:
 
 
 @pytest.mark.parametrize("diaspora", ["ISRAEL", "DIASPORA"])
-@pytest.mark.parametrize("language", ["english", "french", "hebrew"])
+@pytest.mark.parametrize("language", typing.get_args(Language))
 def test_get_all_holidays(language: Language, diaspora: str) -> None:
     """Test the method to get all the holiday descriptions in a specified language."""
 

--- a/tests/test_omer.py
+++ b/tests/test_omer.py
@@ -7,12 +7,15 @@ from syrupy.assertion import SnapshotAssertion
 from hdate import HDate, HebrewDate
 from hdate.hebrew_date import Months
 from hdate.omer import Nusach, Omer
+from hdate.translator import Language
 from tests.conftest import valid_hebrew_date
 
 
 @pytest.mark.parametrize("nusach", list(Nusach))
 @pytest.mark.parametrize("language", ["hebrew", "english", "french"])
-def test_get_omer(language: str, nusach: Nusach, snapshot: SnapshotAssertion) -> None:
+def test_get_omer(
+    language: Language, nusach: Nusach, snapshot: SnapshotAssertion
+) -> None:
     """Test the value returned by calculating the Omer."""
     for omer_day in range(50):
         omer = Omer(total_days=omer_day, language=language, nusach=nusach)

--- a/tests/test_omer.py
+++ b/tests/test_omer.py
@@ -1,5 +1,7 @@
 """Tests relating to Sefirat HaOmer."""
 
+import typing
+
 import pytest
 from hypothesis import given, strategies
 from syrupy.assertion import SnapshotAssertion
@@ -12,7 +14,7 @@ from tests.conftest import valid_hebrew_date
 
 
 @pytest.mark.parametrize("nusach", list(Nusach))
-@pytest.mark.parametrize("language", ["hebrew", "english", "french"])
+@pytest.mark.parametrize("language", typing.get_args(Language))
 def test_get_omer(
     language: Language, nusach: Nusach, snapshot: SnapshotAssertion
 ) -> None:

--- a/tests/test_tekufot.py
+++ b/tests/test_tekufot.py
@@ -5,6 +5,7 @@ import datetime as dt
 import pytest
 
 from hdate.tekufot import Nusachim, Tekufot, TekufotNames
+from hdate.translator import Language
 
 
 @pytest.mark.parametrize(
@@ -89,7 +90,7 @@ def test_get_cheilat_geshamim(date: dt.date, expected: dt.date, diaspora: bool) 
     ],
 )
 def test_tekufot_prayer_for_date(
-    date: dt.date, tradition: Nusachim, language: str, expected: str
+    date: dt.date, tradition: Nusachim, language: Language, expected: str
 ) -> None:
     """
     Tests that the method get_prayer_for_date returns the expected phrase

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,21 +1,21 @@
 """Tests for the TranslatorMixin class."""
 
+import typing
+
 import pytest
 
 from hdate.hebrew_date import Months
 from hdate.translator import Language, TranslatorMixin
 
-LANGUAGES = ["english", "french", "hebrew"]
 
-
-@pytest.mark.parametrize("language", LANGUAGES)
+@pytest.mark.parametrize("language", typing.get_args(Language))
 def test_available_languages(language: Language) -> None:
     """Test the available_languages method."""
     month = Months.TISHREI
     assert language[:2] in month.available_languages()
 
 
-@pytest.mark.parametrize("language", LANGUAGES)
+@pytest.mark.parametrize("language", typing.get_args(Language))
 def test_set_language(language: Language) -> None:
     """Test the load_language method."""
     month = Months.TISHREI

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -3,20 +3,20 @@
 import pytest
 
 from hdate.hebrew_date import Months
-from hdate.translator import TranslatorMixin
+from hdate.translator import Language, TranslatorMixin
 
 LANGUAGES = ["english", "french", "hebrew"]
 
 
 @pytest.mark.parametrize("language", LANGUAGES)
-def test_available_languages(language: str) -> None:
+def test_available_languages(language: Language) -> None:
     """Test the available_languages method."""
     month = Months.TISHREI
     assert language[:2] in month.available_languages()
 
 
 @pytest.mark.parametrize("language", LANGUAGES)
-def test_set_language(language: str) -> None:
+def test_set_language(language: Language) -> None:
     """Test the load_language method."""
     month = Months.TISHREI
     result = {
@@ -31,7 +31,7 @@ def test_set_language(language: str) -> None:
 def test_non_existing_language(caplog: pytest.LogCaptureFixture) -> None:
     """Test the load_language method."""
     month = Months.TISHREI
-    month.set_language("non-existing-language")
+    month.set_language("non-existing-language")  # type: ignore
     assert (
         "Language non-existing-language not found, falling back to english"
         in caplog.text


### PR DESCRIPTION
### **User description**
# Description

# Closes issue(s)

  Fixes: #<issue number>

# Changes included (select only one)

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist

- [ ] Code passes tox


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `Language` as a `Literal` type for language definitions.

- Replaced `str` with `Language` type for language parameters across modules.

- Updated tests to use `Language` type for parameterized language inputs.

- Improved type safety and consistency in language handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>date.py</strong><dd><code>Replace `str` with `Language` type for language parameter</code></dd></td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/194/files#diff-3e412f861a6290e9a28c950d3123aa1e4ff20654558862fb11c8365ec73953cd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>holidays.py</strong><dd><code>Update `get_all_names` method to use `Language` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/194/files#diff-728ab9ad49daf819af84ede10569bb61c8a4acdbc07cbdb3bf6feff0487c9923">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>omer.py</strong><dd><code>Refactor `language` attribute to use `Language` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/194/files#diff-d388718a024595496b8da03ecc5fef7a12daf6b7427682dc2beda0a3aaab9d4f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tekufot.py</strong><dd><code>Use `Language` type for `language` attribute in `Tekufot`</code></dd></td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/194/files#diff-431cff1cdbbd9dfa435df6d6dc7a9f3b8eeff3b0353025fea6188adfe6560258">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translator.py</strong><dd><code>Define `Language` as a `Literal` type and refactor usage</code>&nbsp; </dd></td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/194/files#diff-6cadc60b6d2d96af157e3d5c86ffc223e38b345b5fae04c7822b69da06a9f76f">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zmanim.py</strong><dd><code>Refactor `language` attribute to use `Language` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/194/files#diff-89e8de55c95c9c0b90901f04831894c6c061c61df9d24e1b679623459b3d453f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_holidays.py</strong><dd><code>Update holiday tests to use `Language` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/194/files#diff-7de1e6ae260f3898f3274b1f1d72ef9a9f98fd785e9253a022fe88cd524003c0">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_omer.py</strong><dd><code>Refactor Omer tests to use `Language` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/194/files#diff-68e7f638f2e4bb8a37a2d33ad3dac2838645ceeba779a83c3d4823c3a7eb8d54">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tekufot.py</strong><dd><code>Update Tekufot tests to use `Language` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/194/files#diff-c51d3729871033d7283a360b2f802961d55bafb7a13882c25c840d02c6217853">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_translator.py</strong><dd><code>Update TranslatorMixin tests to use `Language` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/194/files#diff-24e3746deb8d92881995922ec10d5efa5b2b14835301a91025db9b3457774b29">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>