### PR TITLE
Add implementation for erev shabbat and chag

### DIFF
--- a/hdate/date_info.py
+++ b/hdate/date_info.py
@@ -176,6 +176,11 @@ class HDateInfo(TranslatorMixin):  # pylint: disable=too-many-instance-attribute
         return HDateInfo(next_shabbat, diaspora=self.diaspora, language=self.language)
 
     @property
+    def upcoming_erev_shabbat(self) -> HDateInfo:
+        """Return the HDateInfo for the upcoming or current Erev Shabbat (Friday)."""
+        return self.upcoming_shabbat.previous_day
+
+    @property
     def upcoming_yom_tov(self) -> HDateInfo:
         """Return the HDateInfo for the upcoming or current Yom Tov."""
         if self.is_yom_tov:
@@ -187,6 +192,11 @@ class HDateInfo(TranslatorMixin):  # pylint: disable=too-many-instance-attribute
         return HDateInfo(date, self.diaspora, self.language)
 
     @property
+    def upcoming_erev_yom_tov(self) -> HDateInfo:
+        """Return the HDateInfo for the upcoming or current Erev Yom Tov."""
+        return self.upcoming_yom_tov.previous_day
+
+    @property
     def upcoming_shabbat_or_yom_tov(self) -> HDateInfo:
         """Return the HDateInfo for the upcoming or current Shabbat or Yom Tov."""
         if self.is_shabbat or self.is_yom_tov:
@@ -195,6 +205,16 @@ class HDateInfo(TranslatorMixin):  # pylint: disable=too-many-instance-attribute
         if self.upcoming_yom_tov.gdate < self.upcoming_shabbat.gdate:
             return self.upcoming_yom_tov
         return self.upcoming_shabbat
+
+    @property
+    def upcoming_erev_shabbat_or_erev_yom_tov(self) -> HDateInfo:
+        """Return the HDateInfo for upcoming or current Erev Shabbat or Erev Yom Tov."""
+        if self in (self.upcoming_erev_shabbat, self.upcoming_erev_yom_tov):
+            return self
+
+        if self.upcoming_erev_yom_tov.gdate < self.upcoming_erev_shabbat.gdate:
+            return self.upcoming_erev_yom_tov
+        return self.upcoming_erev_shabbat
 
     @property
     def first_day(self) -> HDateInfo:

--- a/hdate/date_info.py
+++ b/hdate/date_info.py
@@ -209,12 +209,7 @@ class HDateInfo(TranslatorMixin):  # pylint: disable=too-many-instance-attribute
     @property
     def upcoming_erev_shabbat_or_erev_yom_tov(self) -> HDateInfo:
         """Return the HDateInfo for upcoming or current Erev Shabbat or Erev Yom Tov."""
-        if self in (self.upcoming_erev_shabbat, self.upcoming_erev_yom_tov):
-            return self
-
-        if self.upcoming_erev_yom_tov.gdate < self.upcoming_erev_shabbat.gdate:
-            return self.upcoming_erev_yom_tov
-        return self.upcoming_erev_shabbat
+        return self.upcoming_shabbat_or_yom_tov.previous_day
 
     @property
     def first_day(self) -> HDateInfo:

--- a/hdate/date_info.py
+++ b/hdate/date_info.py
@@ -37,6 +37,7 @@ class HDateInfo(TranslatorMixin):  # pylint: disable=too-many-instance-attribute
     def __post_init__(self) -> None:
         # Initialize private variables
         self._last_updated = ""
+        self._holidays = HolidayDatabase(self.diaspora)
 
         if isinstance(self.date, dt.date):
             self.gdate = self.date
@@ -116,7 +117,7 @@ class HDateInfo(TranslatorMixin):  # pylint: disable=too-many-instance-attribute
     @property
     def holidays(self) -> list[Holiday]:
         """Return the abstract holiday information from holidays table."""
-        holidays_list = HolidayDatabase(diaspora=self.diaspora).lookup(self.hdate)
+        holidays_list = self._holidays.lookup(self.hdate)
 
         for holiday in holidays_list:
             holiday.set_language(self.language)
@@ -186,8 +187,7 @@ class HDateInfo(TranslatorMixin):  # pylint: disable=too-many-instance-attribute
         if self.is_yom_tov:
             return self
 
-        mgr = HolidayDatabase(diaspora=self.diaspora)
-        date = mgr.lookup_next_holiday(self.hdate, [HolidayTypes.YOM_TOV])
+        date = self._holidays.lookup_next_holiday(self.hdate, [HolidayTypes.YOM_TOV])
 
         return HDateInfo(date, self.diaspora, self.language)
 

--- a/hdate/translator.py
+++ b/hdate/translator.py
@@ -33,13 +33,13 @@ class TranslatorMixin:
             super().__init__(*args, **kwargs)
         language = self._language
         if hasattr(self, "language"):
-            language = getattr(self, "language")
+            language = self.language
         self.set_language(language)
 
     def __post_init__(self) -> None:
         language = self._language
         if hasattr(self, "language"):
-            language = getattr(self, "language")
+            language = self.language
         self.set_language(language)
 
     def __str__(self) -> str:

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -136,7 +136,7 @@ class Zmanim(TranslatorMixin):
             time = time.replace(tzinfo=cast(dt.tzinfo, self.location.timezone))
         return time
 
-    def issur_melacha_in_effect(self, time: dt.datetime = dt.datetime.now()) -> bool:
+    def issur_melacha_in_effect(self, time: dt.datetime) -> bool:
         """At the given time, return whether issur melacha is in effect."""
         _time = self._timezone_aware(time)
         if (self.today.is_shabbat or self.today.is_yom_tov) and (
@@ -158,7 +158,7 @@ class Zmanim(TranslatorMixin):
 
         return False
 
-    def erev_shabbat_chag(self, time: dt.datetime = dt.datetime.now()) -> bool:
+    def erev_shabbat_chag(self, time: dt.datetime) -> bool:
         """At the given time, return whether erev shabbat or chag"""
         _time = self._timezone_aware(time)
         if self.candle_lighting is None:  # No need to check further
@@ -173,7 +173,7 @@ class Zmanim(TranslatorMixin):
 
         return False
 
-    def motzei_shabbat_chag(self, time: dt.datetime = dt.datetime.now()) -> bool:
+    def motzei_shabbat_chag(self, time: dt.datetime) -> bool:
         """At the given time, return whether motzei shabbat or chag"""
         _time = self._timezone_aware(time)
         if self.havdalah is None:  # If there's no havdala, no need to check further

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "astral", "dev", "docs", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:6a9e1e4fd924843e09ae92d215545ffe9cff846cd4a2fa60effd8580e88e8d76"
+content_hash = "sha256:951725a56fcd427c7e46934b6b0dc4fb9e2f265cf17ef9707be6044c606a3296"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -55,7 +55,7 @@ name = "attrs"
 version = "24.3.0"
 requires_python = ">=3.8"
 summary = "Classes Without Boilerplate"
-groups = ["test"]
+groups = ["dev", "test"]
 files = [
     {file = "attrs-24.3.0-py3-none-any.whl", hash = "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"},
     {file = "attrs-24.3.0.tar.gz", hash = "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff"},
@@ -477,6 +477,21 @@ dependencies = [
 files = [
     {file = "flake8-7.1.1-py2.py3-none-any.whl", hash = "sha256:597477df7860daa5aa0fdd84bf5208a043ab96b8e96ab708770ae0364dd03213"},
     {file = "flake8-7.1.1.tar.gz", hash = "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38"},
+]
+
+[[package]]
+name = "flake8-bugbear"
+version = "24.12.12"
+requires_python = ">=3.8.1"
+summary = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
+groups = ["dev"]
+dependencies = [
+    "attrs>=22.2.0",
+    "flake8>=6.0.0",
+]
+files = [
+    {file = "flake8_bugbear-24.12.12-py3-none-any.whl", hash = "sha256:1b6967436f65ca22a42e5373aaa6f2d87966ade9aa38d4baf2a1be550767545e"},
+    {file = "flake8_bugbear-24.12.12.tar.gz", hash = "sha256:46273cef0a6b6ff48ca2d69e472f41420a42a46e24b2a8972e4f0d6733d12a64"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ profile = "black"
 
 [tool.pylint.format]
 max-line-length = "88"
+ignore = [
+    "C0301",  # line too long - handled by black
+]
 
 [tool.pytest.ini_options]
 # Show summary output for all types of failures
@@ -52,12 +55,13 @@ addopts = "-ra --doctest-modules --doctest-glob=*.rst -n auto --timeout=300"
 [dependency-groups]
 dev = [
     "tox>=4.24.1",
+    "tox-pdm>=0.7.2",
+    "flake8>=7.1.1",
+    "flake8-bugbear>=24.12.12",
     "pylint>=3.3.4",
     "isort>=6.0.0",
     "black>=25.1.0",
-    "tox-pdm>=0.7.2",
     "pre-commit>=4.1.0",
-    "flake8>=7.1.1",
     "mypy>=1.14.1",
 ]
 test = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [flake8]
-max-line-length = 88
+max-line-length = 80
+extend-select = B950
+extend-ignore = E203,E501,E701

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -49,7 +49,7 @@ def test_str_without_name() -> None:
             super().__init__()
 
     foo_class = Foo()
-    assert getattr(foo_class, "_language") == "hebrew"
+    assert foo_class._language == "hebrew"  # pylint: disable=protected-access
     with pytest.raises(NameError):
         str(foo_class)
 


### PR DESCRIPTION
# Description
Add a property for calculating erev Shabbat and chag, making the home-assistant integration easier.
This is especially important when we have a multi-day Chag/Shabbat.

# Closes issue(s)

  Fixes: #197 
  Supports: home-assistant/core#127694

# Changes included (select only one)

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist

- [ ] Code passes tox
