### PR TITLE
Improve HebrewDate comparison performance

### DIFF
--- a/hdate/hebrew_date.py
+++ b/hdate/hebrew_date.py
@@ -166,7 +166,7 @@ SHORT_MONTHS = tuple(month for month in Months if month.length == 29)
 CHANGING_MONTHS = tuple(month for month in Months if callable(month.length))
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class HebrewDate(TranslatorMixin):
     """Define a Hebrew date object."""
 
@@ -234,15 +234,23 @@ class HebrewDate(TranslatorMixin):
         if not isinstance(other, HebrewDate):
             return NotImplemented
         if self.year == 0 or other.year == 0:
-            return (self.month, self.day) == (other.month, other.day)
-        return (self.year, self.month, self.day) == (other.year, other.month, other.day)
+            return (self.month.value, self.day) == (other.month.value, other.day)
+        return (self.year, self.month.value, self.day) == (
+            other.year,
+            other.month.value,
+            other.day,
+        )
 
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, HebrewDate):
             return NotImplemented
         if self.year == 0 or other.year == 0:
-            return (self.month, self.day) < (other.month, other.day)
-        return (self.year, self.month, self.day) < (other.year, other.month, other.day)
+            return (self.month.value, self.day) < (other.month.value, other.day)
+        return (self.year, self.month.value, self.day) < (
+            other.year,
+            other.month.value,
+            other.day,
+        )
 
     def __le__(self, other: object) -> bool:
         if not isinstance(other, HebrewDate):


### PR DESCRIPTION
### **User description**
# Description

Usage of dataclass(slots) argument requires Python 3.10, this is currently waiting for the deprecation of 3.9


# Closes issue(s)

  Fixes: #<issue number>

# Changes included (select only one)

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist

- [ ] Code passes tox


___

### **PR Type**
Enhancement


___

### **Description**
- Add `slots=True` to dataclass decorator for memory optimization

- Replace month enum comparisons with `.value` for faster performance

- Optimize `__eq__` and `__lt__` methods in HebrewDate class


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HebrewDate dataclass"] -->|add slots=True| B["Reduced memory footprint"]
  C["Comparison methods"] -->|use month.value| D["Faster enum comparisons"]
  B --> E["Performance improvement"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hebrew_date.py</strong><dd><code>Optimize HebrewDate comparison and memory usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hdate/hebrew_date.py

<ul><li>Added <code>slots=True</code> parameter to <code>@dataclass</code> decorator for memory <br>optimization<br> <li> Modified <code>__eq__</code> method to compare <code>month.value</code> instead of month enum <br>objects<br> <li> Modified <code>__lt__</code> method to compare <code>month.value</code> instead of month enum <br>objects<br> <li> Improved code formatting with multi-line tuple comparisons</ul>


</details>


  </td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/217/files#diff-47686b70921c74074a7c69d7e3574b592394aa956ecf157ff65e750e8625838f">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

