### PR TITLE
Fix unsafe default altitude in Location class

### DIFF
--- a/hdate/location.py
+++ b/hdate/location.py
@@ -14,9 +14,15 @@ class Location:
     latitude: float = 31.778
     longitude: float = 35.235
     timezone: Union[str, tzinfo] = ZoneInfo("Asia/Jerusalem")
-    altitude: float = 754
+    altitude: float | None = None
     diaspora: bool = False
 
     def __post_init__(self) -> None:
         if isinstance(self.timezone, str):
             object.__setattr__(self, "timezone", ZoneInfo(self.timezone))
+
+        if self.altitude is None:
+            if self.name == "Jerusalem" and self.latitude == 31.778:
+                object.__setattr__(self, "altitude", 754)
+            else:
+                object.__setattr__(self, "altitude", 0)


### PR DESCRIPTION
### **User description**
# Description

This PR adds an altitude field to the Location dataclass and fixes a critical bug in default value handling.

Previously, altitude defaulted to 754m (Jerusalem). This meant any new location defined without an explicit altitude (e.g., Tel Aviv) would inherit Jerusalem's elevation, causing incorrect "Dip of the Horizon" calculations and skewing Zmanim times by ~3-4 minutes.

Changes:

Added altitude field (defaulting to None as a sentinel).

Updated __post_init__ to assign 0 (sea level) as the safe fallback for new locations.

Retained 754 only when the default Jerusalem coordinates are used.

# Closes issue(s)

  Fixes: #<issue number>

# Changes included (select only one)

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist

- [x] Code passes tox


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed unsafe altitude default that caused incorrect Zmanim calculations

- Changed altitude field to optional with None sentinel value

- Added logic to assign 754m only for default Jerusalem location

- Assigns 0m (sea level) as safe fallback for all other locations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["altitude field<br/>changed to None"] --> B["__post_init__ logic"]
  B --> C{"Is default<br/>Jerusalem?"}
  C -->|Yes| D["Set altitude to 754m"]
  C -->|No| E["Set altitude to 0m"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>location.py</strong><dd><code>Add conditional altitude initialization logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hdate/location.py

<ul><li>Changed <code>altitude</code> field type from <code>float</code> to <code>float | None</code> with default <br><code>None</code><br> <li> Added <code>__post_init__</code> logic to conditionally set altitude based on <br>location<br> <li> Assigns 754m only when default Jerusalem coordinates are detected<br> <li> Assigns 0m (sea level) as safe fallback for all other locations</ul>


</details>


  </td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/222/files#diff-60fa48d1ad29812d9558f73235c31272c99a924c65c8fccadfcb986ffb64f2c2">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

