### PR TITLE
Fix typo & refactor _datetime_to_minutes_offset

### DIFF
--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -262,14 +262,11 @@ class Zmanim(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
             int(720.0 - 4.0 * longitude + hour_angle - eqtime),
         )
 
-    def _datetime_to_minutes_offest(self, time: dt.datetime) -> int:
-        """Return the time in minutes from 00:00 (utc) for a given time."""
-        return (
-            time.hour * 60
-            + time.minute
-            + (1 if time.second >= 30 else 0)
-            + int((time.date() - self.date).total_seconds() // 60)
-        )
+    def _datetime_to_minutes_offset(self, time: dt.datetime) -> int:
+        """Return minutes offset from self.date at 00:00."""
+        anchor = dt.datetime.combine(self.date, dt.time.min, tzinfo=time.tzinfo)
+        delta_seconds = (time - anchor).total_seconds()
+        return int(delta_seconds / 60 + 0.5)
 
     def _get_utc_time_of_transit(self, zenith: float, rising: bool) -> int:
         """Return the time in minutes from 00:00 (utc) for a given sun altitude."""
@@ -277,7 +274,7 @@ class Zmanim(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
             latitude=self.location.latitude,
             longitude=self.location.longitude,
         )
-        return self._datetime_to_minutes_offest(
+        return self._datetime_to_minutes_offset(
             astral.sun.time_of_transit(
                 astral_observer,
                 self.date,


### PR DESCRIPTION
### **User description**
# Description

This PR refactors the minute offset calculation to use standard datetime deltas and fixes a legacy naming typo.

Changes:

Refactor: Replaced manual component arithmetic with (time - anchor).total_seconds() for cleaner, standard logic.

Fix: Renamed _datetime_to_minutes_offest to _datetime_to_minutes_offset.

Timezones: Logic now explicitly respects the input datetime's timezone when creating the calculation anchor, preventing mixed-offset errors.

Impact:

Correctness: Eliminates edge cases where time.date() and self.date might imply different timezones.

Hygiene: Fixes the long-standing function name typo.

# Closes issue(s)

  Fixes: #<issue number>

# Changes included (select only one)

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

# Checklist

- [x] Code passes tox


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed function name typo: `_datetime_to_minutes_offest` to `_datetime_to_minutes_offset`

- Refactored offset calculation using standard `datetime.timedelta` for cleaner logic

- Improved timezone handling by explicitly preserving input datetime's timezone

- Enhanced rounding behavior using banker's rounding (0.5 offset)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual component arithmetic<br/>hour*60 + minute + seconds"] -->|Refactor| B["Standard timedelta<br/>time - anchor"]
  C["Typo: _offest"] -->|Fix| D["Correct: _offset"]
  E["Mixed timezone handling<br/>time.date() vs self.date"] -->|Improve| F["Explicit tzinfo preservation<br/>anchor with time.tzinfo"]
  B --> G["Cleaner, more maintainable code"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zmanim.py</strong><dd><code>Refactor offset calculation with timezone awareness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hdate/zmanim.py

<ul><li>Renamed function from <code>_datetime_to_minutes_offest</code> to <br><code>_datetime_to_minutes_offset</code> (typo fix)<br> <li> Replaced manual time component arithmetic with standard <br><code>datetime.timedelta</code> calculation<br> <li> Created timezone-aware anchor datetime using <code>dt.datetime.combine()</code> <br>with <code>time.tzinfo</code><br> <li> Changed rounding from conditional second-based rounding to banker's <br>rounding with 0.5 offset<br> <li> Updated function call at line 282 to use corrected function name</ul>


</details>


  </td>
  <td><a href="https://github.com/py-libhdate/py-libhdate/pull/223/files#diff-89e8de55c95c9c0b90901f04831894c6c061c61df9d24e1b679623459b3d453f">+6/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

