### PR TITLE
Use location altitude in Astral zmanim calculations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,23 +48,23 @@ Provide the times of the day in Hebrew...
     >>> c = hdate.Location("פתח תקוה", 32.08707, 34.88747, "Asia/Jerusalem", 54)
     >>> z = hdate.Zmanim(date=datetime.date(2016, 4, 18), location=c)
     >>> print(z)
-    עלות השחר - 04:52:00
-    זמן טלית ותפילין - 05:18:00
-    הנץ החמה - 06:08:00
-    סוף זמן ק"ש מג"א - 08:46:00
-    סוף זמן ק"ש גר"א - 09:23:00
-    סוף זמן תפילה מג"א - 10:04:00
-    סוף זמן תפילה גר"א - 10:28:00
+    עלות השחר - 04:50:00
+    זמן טלית ותפילין - 05:16:00
+    הנץ החמה - 06:07:00
+    סוף זמן ק"ש מג"א - 08:45:00
+    סוף זמן ק"ש גר"א - 09:22:00
+    סוף זמן תפילה מג"א - 10:03:20
+    סוף זמן תפילה גר"א - 10:27:00
     חצות היום - 12:40:00
-    מנחה גדולה - 13:10:30
+    מנחה גדולה - 13:09:30
     מנחה גדולה 30 דק - 13:10:00
-    מנחה קטנה - 16:25:30
-    פלג המנחה - 17:50:45
-    שקיעה - 19:12:00
-    מוצאי צום - 19:40:00
-    מוצאי שבת - 19:50:00
-    צאת הכוכבים (18 דק) - 19:31:30
-    לילה לרבנו תם - 20:30:00
+    מנחה קטנה - 16:24:30
+    פלג המנחה - 17:51:45
+    שקיעה - 19:13:00
+    מוצאי צום - 19:41:00
+    מוצאי שבת - 19:51:00
+    צאת הכוכבים (18 דק) - 19:32:30
+    לילה לרבנו תם - 20:31:00
     חצות הלילה - 00:40:00
 
 ... and in English.
@@ -75,23 +75,23 @@ Provide the times of the day in Hebrew...
     >>> set_language("en")
     >>> z = hdate.Zmanim(date=datetime.date(2016, 4, 18), location=c)
     >>> print(z)
-    Alot HaShachar - 04:52:00
-    Talit & Tefilin's time - 05:18:00
-    Sunrise - 06:08:00
-    Shema EOT MG"A - 08:46:00
-    Shema EOT GR"A - 09:23:00
-    Tefila EOT MG"A - 10:04:00
-    Tefila EOT GR"A - 10:28:00
+    Alot HaShachar - 04:50:00
+    Talit & Tefilin's time - 05:16:00
+    Sunrise - 06:07:00
+    Shema EOT MG"A - 08:45:00
+    Shema EOT GR"A - 09:22:00
+    Tefila EOT MG"A - 10:03:20
+    Tefila EOT GR"A - 10:27:00
     Midday - 12:40:00
-    Big Mincha - 13:10:30
+    Big Mincha - 13:09:30
     Big Mincha 30 min - 13:10:00
-    Small Mincha - 16:25:30
-    Plag Mincha - 17:50:45
-    Sunset - 19:12:00
-    End of fast - 19:40:00
-    End of Shabbat - 19:50:00
-    Tset Hakochavim (18 minutes) - 19:31:30
-    Night by Rabbeinu Tam - 20:30:00
+    Small Mincha - 16:24:30
+    Plag Mincha - 17:51:45
+    Sunset - 19:13:00
+    End of fast - 19:41:00
+    End of Shabbat - 19:51:00
+    Tset Hakochavim (18 minutes) - 19:32:30
+    Night by Rabbeinu Tam - 20:31:00
     Midnight - 00:40:00
 
 ===========

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -111,7 +111,7 @@ Now we can go ahead and ask ``hdate`` for the **Halachic times** for a given dat
 
     >>> zmanim = Zmanim(date(2025, 1, 15), location)
     >>> zmanim.alot_hashachar.local
-    datetime.datetime(2025, 1, 15, 5, 25, tzinfo=zoneinfo.ZoneInfo(key='Asia/Jerusalem'))
+    datetime.datetime(2025, 1, 15, 5, 24, tzinfo=zoneinfo.ZoneInfo(key='Asia/Jerusalem'))
 
 To get a list of the supported zmanim, you'll want to inspect the keys returned by the
 ``zmanim`` property.

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -26,6 +26,8 @@ list of ``Holiday`` objects. If the given date is not a holiday the list will be
     
     >>> from hdate.holidays import HolidayDatabase
     >>> from hdate import HebrewDate, Months
+    >>> from hdate.translator import set_language
+    >>> set_language("en")
     >>> db = HolidayDatabase(diaspora=False)
     >>> holidays = db.lookup(HebrewDate(5785, Months.ADAR, 14))
     >>> print(holidays[0])

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -273,6 +273,7 @@ class Zmanim(TranslatorMixin):  # pylint: disable=too-many-instance-attributes
         astral_observer = astral.Observer(
             latitude=self.location.latitude,
             longitude=self.location.longitude,
+            elevation=self.location.altitude or 0.0,
         )
         return self._datetime_to_minutes_offset(
             astral.sun.time_of_transit(

--- a/tests/__snapshots__/test_hdate_api.ambr
+++ b/tests/__snapshots__/test_hdate_api.ambr
@@ -4,45 +4,45 @@
 # ---
 # name: TestZmanimAPI.test_readme_example_english[Petah Tikva]
   '''
-  Alot HaShachar - 04:52:00
-  Talit & Tefilin's time - 05:18:00
-  Sunrise - 06:08:00
-  Shema EOT MG"A - 08:46:00
-  Shema EOT GR"A - 09:23:00
-  Tefila EOT MG"A - 10:04:00
-  Tefila EOT GR"A - 10:28:00
+  Alot HaShachar - 04:50:00
+  Talit & Tefilin's time - 05:16:00
+  Sunrise - 06:07:00
+  Shema EOT MG"A - 08:45:00
+  Shema EOT GR"A - 09:22:00
+  Tefila EOT MG"A - 10:03:20
+  Tefila EOT GR"A - 10:27:00
   Midday - 12:40:00
-  Big Mincha - 13:10:30
+  Big Mincha - 13:09:30
   Big Mincha 30 min - 13:10:00
-  Small Mincha - 16:25:30
-  Plag Mincha - 17:50:45
-  Sunset - 19:12:00
-  End of fast - 19:40:00
-  End of Shabbat - 19:50:00
-  Tset Hakochavim (18 minutes) - 19:31:30
-  Night by Rabbeinu Tam - 20:30:00
+  Small Mincha - 16:24:30
+  Plag Mincha - 17:51:45
+  Sunset - 19:13:00
+  End of fast - 19:41:00
+  End of Shabbat - 19:51:00
+  Tset Hakochavim (18 minutes) - 19:32:30
+  Night by Rabbeinu Tam - 20:31:00
   Midnight - 00:40:00
   '''
 # ---
 # name: TestZmanimAPI.test_readme_example_hebrew[Petah Tikva]
   '''
-  עלות השחר - 04:52:00
-  זמן טלית ותפילין - 05:18:00
-  הנץ החמה - 06:08:00
-  סוף זמן ק"ש מג"א - 08:46:00
-  סוף זמן ק"ש גר"א - 09:23:00
-  סוף זמן תפילה מג"א - 10:04:00
-  סוף זמן תפילה גר"א - 10:28:00
+  עלות השחר - 04:50:00
+  זמן טלית ותפילין - 05:16:00
+  הנץ החמה - 06:07:00
+  סוף זמן ק"ש מג"א - 08:45:00
+  סוף זמן ק"ש גר"א - 09:22:00
+  סוף זמן תפילה מג"א - 10:03:20
+  סוף זמן תפילה גר"א - 10:27:00
   חצות היום - 12:40:00
-  מנחה גדולה - 13:10:30
+  מנחה גדולה - 13:09:30
   מנחה גדולה 30 דק - 13:10:00
-  מנחה קטנה - 16:25:30
-  פלג המנחה - 17:50:45
-  שקיעה - 19:12:00
-  מוצאי צום - 19:40:00
-  מוצאי שבת - 19:50:00
-  צאת הכוכבים (18 דק) - 19:31:30
-  לילה לרבנו תם - 20:30:00
+  מנחה קטנה - 16:24:30
+  פלג המנחה - 17:51:45
+  שקיעה - 19:13:00
+  מוצאי צום - 19:41:00
+  מוצאי שבת - 19:51:00
+  צאת הכוכבים (18 דק) - 19:32:30
+  לילה לרבנו תם - 20:31:00
   חצות הלילה - 00:40:00
   '''
 # ---

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -75,6 +75,20 @@ def test_extreme_zmanim(location: Location, result: dt.time) -> None:
     )
 
 
+@pytest.mark.skipif(not _ASTRAL, reason="Altitude is only used in Astral transit mode")
+def test_altitude_affects_astral_zmanim() -> None:
+    """Higher altitude should advance sunrise and delay sunset."""
+    day = dt.date.today()
+    sea_level = Location(altitude=0)
+    high_altitude = Location()
+
+    sea_level_zmanim = Zmanim(date=day, location=sea_level)
+    high_altitude_zmanim = Zmanim(date=day, location=high_altitude)
+
+    assert high_altitude_zmanim.netz_hachama.local < sea_level_zmanim.netz_hachama.local
+    assert high_altitude_zmanim.shkia.local > sea_level_zmanim.shkia.local
+
+
 # Times are assumed for NYC.
 CANDLES_TEST = [
     (dt.datetime(2018, 9, 7, 13, 1), 18, dt.datetime(2018, 9, 7, 19, 0), False),
@@ -224,7 +238,7 @@ def test_candle_lighting_erev_shabbat_is_yom_tov(location: Location) -> None:
     assert zman.candle_lighting == actual_candle_lighting
 
 
-@given(name=strategies.text().filter(lambda s: s not in dir(Zmanim)))
+@given(name=strategies.text().filter(lambda s: s not in dir(Zmanim())))
 def test_non_existing_attribute(name: str) -> None:
     """Test trying to access a Zmanim attribute that isn't in the class."""
     with pytest.raises(AttributeError):


### PR DESCRIPTION
# Description

This PR makes Astral-based zmanim calculations respect `Location.altitude` and updates the related tests and documentation to match the new output.

## Changes by file

- `hdate/zmanim.py`
  - Added `elevation=self.location.altitude or 0.0` when constructing the Astral `Observer`.
  - Before this change, Astral transit calculations ignored the configured location altitude.
  - Note that Home Assistant already sets `location.altitude` correctly [here](https://github.com/home-assistant/core/blob/d9b4d633d29a59dca3aee0eabf4c97d522a2502c/homeassistant/components/jewish_calendar/__init__.py#L68).
    - Home Assistant always uses meters for `location.altitude` as documented [here](https://www.home-assistant.io/integrations/homeassistant/?utm_source=chatgpt.com#elevation).
    - Astral expects `elevation` in meters as documented [here](https://github.com/sffjunkie/astral/blob/ac23ab5c0c69837d8fa1a5bb184c2d6d125b26b3/src/astral/__init__.py#L251).

- `tests/test_zmanim.py`
  - Added `test_altitude_affects_astral_zmanim` to verify the new behavior: for the same default Jerusalem location, a higher altitude produces an earlier sunrise and later sunset.
  - Updated `test_non_existing_attribute` to filter against `dir(Zmanim())` instead of `dir(Zmanim)`, so it validates against the actual instance attribute surface and avoids false failures on dynamic zmanim attributes.

- `README.rst`
  - Updated the documented Hebrew and English `Zmanim` example outputs for Petah Tikva.
  - These values changed because the example location includes altitude, which now affects Astral calculations.

- `docs/source/quickstart.rst`
  - Updated the documented `alot_hashachar.local` example by one minute to match the new altitude-aware calculation.

- `docs/source/user_guide.rst`
  - Added `set_language("en")` in the holiday lookup doctest so the example is deterministic and does not depend on prior test language state.

- `tests/__snapshots__/test_hdate_api.ambr`
  - Refreshed the stored Hebrew and English snapshot outputs for the README-style `Zmanim` examples to match the new altitude-aware values.

# Closes issue(s)

  Fixes: #<issue number>

# Changes included (select only one)

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible)

Not sure how to classify this PR. It can be seen as a bug-fix since the altitude was previously ignored. It can be seen as a new-feature, and it can also be seen as a breaking change...

# Checklist

- [x] Code passes tox

Ran the local CI-equivalent tox environments available on this machine:

- Passed: `lint`
- Passed: `py312-astral`
- Passed: `py312-no_astral`
- Passed: `py313-astral`
- Passed: `py313-no_astral`